### PR TITLE
(#9583) Fix provider detection for gentoo and unsupported linuxes for the

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -19,8 +19,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   commands :iptables => '/sbin/iptables'
   commands :iptables_save => '/sbin/iptables-save'
 
-  defaultfor :operatingsystem => [:redhat, :debian, :ubuntu, :fedora, :suse, :centos, :sles, :oel, :ovm]
-  confine :operatingsystem => [:redhat, :debian, :ubuntu, :fedora, :suse, :centos, :sles, :oel, :ovm]
+  defaultfor :kernel => :linux
 
   @resource_map = {
     :burst => "--limit-burst",


### PR DESCRIPTION
(#9583) Fix provider detection for gentoo and unsupported linuxes for the iptables provider.

Previously we had fairly specific confine settings for named distributions
of linux for the iptables provider. This was silly, since the commands
defined in the provider should be enough to confine the provider to Linux
only systems.

I've removed the confine, and replaced the defaultfor to be:

  :kernel => :linux

Which should avoid the need to keep adding extra Linux distributions.

I've also added some spec tests for provider detection which should help
catch any failures around the command based detection in the future.
