### PR TITLE
(#9439) fix parsing and deleting existing rules

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -195,6 +195,10 @@ Puppet::Type.newtype(:firewall) do
     desc "Rate limiting burst value (per second)."
     newvalue(/^\d+$/)
   end
+
+  newparam(:line) do
+    desc 'Read-only property for caching the rule line'
+  end
   
   validate do
     debug("[validate]")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,6 @@
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-p dir
-
 # Don't want puppet getting the command line arguments for rake or autotest
 ARGV.clear
 


### PR DESCRIPTION
This change improves parsing of existing rules. It also (slightly) improves the delete method for rules both managed and not managed by Puppet by using deleting via the actual rule line instead of position. This makes it easier to delete existing rules using purge.
