### PR TITLE
Add ability to accept a range of ports for the dport parameter.

### DIFF
--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -52,8 +52,10 @@ module Puppet::Util::Firewall
         ports << Socket.getservbyname(port) unless port.kind_of?(Integer)
       end
       ports
-    else
+    elsif value.kind_of?(Integer)
       Socket.getservbyname(value)
+    else
+      value
     end
   end
 end


### PR DESCRIPTION
This simple change makes it possible to provide a range of port values in the form start:end ie. 5400:5600.

Prior to this change, you would see error messages like this:
Failed to apply catalog: Parameter dport failed: Munging failed for value "5400:5600" in class dport: no such service 5400:5600/tcp
