### PR TITLE
(#9362) Create action property and perform transformation for accept, dro

### DIFF
--- a/examples/iptables/test.pp
+++ b/examples/iptables/test.pp
@@ -1,11 +1,11 @@
 firewall { '000 allow foo':
   dport => [7061, 7062],
-  jump => "ACCEPT",
+  action => accept,
   proto => "tcp",
 }
 
 firewall { '001 allow boo':
-  jump => "ACCEPT",
+  action => accept,
   iniface => "eth0",
   sport => "123",
   dport => "123",
@@ -24,84 +24,84 @@ firewall { '100 snat for network foo2':
 }
 
 firewall { '999 bar':
+  action => accept,
   dport => "1233",
   proto => "tcp",
-  jump => "DROP",
 }
 
 firewall { '002 foo':
+  action => drop,
   dport => "1233",
   proto => "tcp",
-  jump => "DROP",
 }
 
 firewall { '010 icmp':
+  action => accept,
   proto => "icmp",
   icmp => "echo-reply",
-  jump => "ACCEPT",
 }
 
 firewall { '010 INPUT allow loopback':
+  action => accept,
   iniface => 'lo',
   chain => 'INPUT',
-  jump => 'ACCEPT'
 }
 
 firewall { '005 INPUT disregard DHCP':
+  action => drop,
   dport => ['bootpc', 'bootps'],
-  jump => 'DROP',
   proto => 'udp'
 }
 
 firewall { '006 INPUT disregard netbios':
+  action => drop,
   proto => 'udp',
   dport => ['netbios-ns', 'netbios-dgm', 'netbios-ssn'],
-  jump => 'DROP'
 }
 
 firewall { '006 Disregard CIFS':
+  action => drop,
   dport => 'microsoft-ds',
-  jump => 'DROP',
   proto => 'tcp'
 }
 
 firewall { '050 INPUT drop invalid':
+  action => drop,
   state => 'INVALID',
-  jump => 'DROP'
 }
 
 firewall { '051 INPUT allow related and established':
+  action => accept,
   state => ['RELATED', 'ESTABLISHED'],
-  jump => 'ACCEPT'
 }
 
 firewall { '053 INPUT allow ICMP':
+  action => accept,
   icmp => '8',
   proto => 'icmp',
-  jump => 'ACCEPT'
 }
 
 firewall { '055 INPUT allow DNS':
+  action => accept,
   proto => 'udp',
-  jump => 'ACCEPT',
   sport => 'domain'
 }
 
 firewall { '999 FORWARD drop':
+  action => drop,
   chain => 'FORWARD',
-  jump => 'DROP'
 }
 
 firewall { '001 OUTPUT allow loopback':
+  action => accept,
   chain => 'OUTPUT',
   outiface => 'lo',
-  jump => 'ACCEPT'
 }
 
 firewall { '100 OUTPUT drop invalid':
+  action => drop,
   chain => 'OUTPUT',
   state => 'INVALID',
-  jump => 'DROP'
 }
 
 resources { 'firewall':

--- a/lib/puppet/provider/firewall.rb
+++ b/lib/puppet/provider/firewall.rb
@@ -38,6 +38,7 @@ class Puppet::Provider::Firewall < Puppet::Provider
     dynamic_methods = self.class.instance_variable_get('@resource_map').keys
     dynamic_methods << :chain
     dynamic_methods << :table
+    dynamic_methods << :action
 
     if dynamic_methods.include?(meth.to_sym) then
       if @property_hash[meth.to_sym] then

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -1,0 +1,102 @@
+# These hashes allow us to iterate across a series of test data
+# creating rspec examples for each parameter to ensure the input :line
+# extrapolates to the desired value for the parameter in question. And
+# vice-versa
+
+# This hash is for testing a line conversion to a hash of parameters
+# which will be used to create a resource.
+ARGS_TO_HASH = { 
+  'long_rule_1' => {
+    :line => '-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061,7062 -m comment --comment "000 allow foo" -j ACCEPT',
+    :table => 'filter',
+    :compare_all => true,
+    :params => {
+      :action => "accept",
+      :chain => "INPUT",
+      :destination => "1.1.1.1",
+      :dport => ["7061","7062"],
+      :ensure => :present,
+      :line => '-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061,7062 -m comment --comment "000 allow foo" -j ACCEPT',
+      :name => "000 allow foo",
+      :proto => "tcp",
+      :provider => "iptables",
+      :source => "1.1.1.1",
+      :sport => ["7061","7062"],
+      :table => "filter",
+    },  
+  },  
+  'action_drop_1' => {
+    :line => '-A INPUT -m comment --comment "000 allow foo" -j DROP',
+    :table => 'filter',
+    :params => {
+      :jump => nil,
+      :action => "drop",
+    },  
+  },  
+  'action_reject_1' => {
+    :line => '-A INPUT -m comment --comment "000 allow foo" -j REJECT',
+    :table => 'filter',
+    :params => {
+      :jump => nil,
+      :action => "reject",
+    },  
+  },
+  'action_nil_1' => {
+    :line => '-A INPUT -m comment --comment "000 allow foo"',
+    :table => 'filter',
+    :params => {
+      :jump => nil,
+      :action => nil,
+    },
+  },
+  'jump_custom_chain_1' => {
+    :line => '-A INPUT -m comment --comment "000 allow foo" -j custom_chain',
+    :table => 'filter',
+    :params => {
+      :jump => "custom_chain",
+      :action => nil,
+    },
+  },
+}
+
+# This hash is for testing converting a hash to an argument line.
+HASH_TO_ARGS = { 
+  'long_rule_1' => {
+    :params => {
+      :action => "accept",
+      :chain => "INPUT",
+      :destination => "1.1.1.1",
+      :dport => ["7061","7062"],
+      :ensure => :present,
+      :name => "000 allow foo",
+      :proto => "tcp",
+      :source => "1.1.1.1",
+      :sport => ["7061","7062"],
+      :table => "filter",
+    },  
+    :args => ["-t", :filter, "-s", "1.1.1.1", "-d", "1.1.1.1", "-p", :tcp, "-m", "multiport", "--sports", "7061,7062", "-m", "multiport", "--dports", "7061,7062", "-m", "comment", "--comment", "000 allow foo", "-j", "ACCEPT"],
+  },  
+  'long_rule_2' => {
+    :params => {
+      :chain => "INPUT",
+      :destination => "2.10.13.3/24",
+      :dport => ["7061"],
+      :ensure => :present,
+      :jump => "my_custom_chain",
+      :name => "700 allow bar",
+      :proto => "udp",
+      :source => "1.1.1.1",
+      :sport => ["7061","7062"],
+      :table => "filter",
+    },  
+    :args => ["-t", :filter, "-s", "1.1.1.1", "-d", "2.10.13.3/24", "-p", :udp, "-m", "multiport", "--sports", "7061,7062", "-m", "multiport", "--dports", "7061", "-m", "comment", "--comment", "700 allow bar", "-j", "my_custom_chain"],
+  },  
+  'no_action' => {
+    :params => {
+      :name => "100 no action",
+      :table => "filter",
+    },  
+    :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", 
+      "100 no action"],
+  }
+}

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -1,24 +1,28 @@
+#!/usr/bin/env rspec
+
 require 'spec_helper'
+require 'puppet/provider/confine/exists'
 
 describe 'iptables provider detection' do
-  before :each do
-    require 'puppet/provider/confine/exists'
-    @exists = Puppet::Provider::Confine::Exists
+  let(:exists) {
+    Puppet::Provider::Confine::Exists
+  }
 
+  before :each do
     # Reset the default provider
     Puppet::Type.type(:firewall).defaultprovider = nil
   end
 
   it "should default to iptables provider if /sbin/iptables[-save] exists" do
     # Stub lookup for /sbin/iptables & /sbin/iptables-save
-    @exists.any_instance.stubs(:which).with("/sbin/iptables").
+    exists.any_instance.stubs(:which).with("/sbin/iptables").
       returns "/sbin/iptables"
-    @exists.any_instance.stubs(:which).with("/sbin/iptables-save").
+    exists.any_instance.stubs(:which).with("/sbin/iptables-save").
       returns "/sbin/iptables-save"
 
     # Every other command should return false so we don't pick up any
     # other providers
-    @exists.any_instance.stubs(:which).with() { |value|
+    exists.any_instance.stubs(:which).with() { |value|
       ! ["/sbin/iptables","/sbin/iptables-save"].include?(value)
     }.returns false
 
@@ -31,7 +35,7 @@ describe 'iptables provider detection' do
 
   it "should raise a default provider error when there are no commands" do
     # Stub all commands lookups so they return nothing 
-    @exists.any_instance.stubs(:which).returns false
+    exists.any_instance.stubs(:which).returns false
 
     # Instantiate a resource instance and make sure it raises an exception
     lambda { resource = Puppet::Type.type(:firewall).new({ 
@@ -41,96 +45,121 @@ describe 'iptables provider detection' do
 end
 
 describe 'iptables provider' do
-  before :each do
-    @provider = Puppet::Type.type(:firewall).provider(:iptables)
-    Puppet::Type::Firewall.stubs(:defaultprovider).returns @provider
-    @provider.stubs(:command).with(:iptables_save).returns "/sbin/iptables-save"
-    @resource = Puppet::Type.type(:firewall).new({
+  let(:provider) { Puppet::Type.type(:firewall).provider(:iptables) }
+  let(:resource) {
+    Puppet::Type.type(:firewall).new({
       :name  => '000 test foo',
-      :chain => 'INPUT',
-      :jump  => 'ACCEPT'
+      :action  => 'accept',
     })
+  }
+
+  before :each do
+    Puppet::Type::Firewall.stubs(:defaultprovider).returns provider
+    provider.stubs(:command).with(:iptables_save).returns "/sbin/iptables-save"
   end
   
   it 'should be able to get a list of existing rules' do
     # Pretend to return nil from iptables
-    @provider.expects(:execute).with(['/sbin/iptables-save']).returns("")
+    provider.expects(:execute).with(['/sbin/iptables-save']).returns("")
 
-    @provider.instances.each do |rule|
-      rule.should be_instance_of(@provider)
-      rule.properties[:provider].to_s.should == @provider.name.to_s
+    provider.instances.each do |rule|
+      rule.should be_instance_of(provider)
+      rule.properties[:provider].to_s.should == provider.name.to_s
     end
   end
 
-  describe 'when converting rules to resources' do
-    before :each do
-      @resource = @provider.rule_to_hash('-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061,7062 -m comment --comment "000 allow foo" -j ACCEPT', 'filter', 0)
-    end
+  # Load in ruby hash for test fixtures.
+  load 'spec/fixtures/iptables/conversion_hash.rb'
 
-    [:name, :table, :chain, :proto, :jump, :source, :destination].each do |param|
-      it "#{param} should be a string" do
-        @resource[param].class.should == String
+  describe 'when converting rules to resources' do
+    ARGS_TO_HASH.each do |test_name,data|
+      describe "for test data '#{test_name}'" do
+        let(:resource) { provider.rule_to_hash(data[:line], data[:table], 0) }
+
+        # If this option is enabled, make sure the parameters exactly match
+        if data[:compare_all] then
+          it "the parameter hash keys should be the same as returned by rules_to_hash" do
+            resource.keys.sort.should == data[:params].keys.sort
+          end
+        end
+
+        # Iterate across each parameter, creating an example for comparison
+        data[:params].each do |param_name, param_value|
+          it "the parameter '#{param_name.to_s}' should match #{param_value.inspect}" do
+            resource[param_name].should == data[:params][param_name]
+          end
+        end
       end
     end
+  end
 
-    [:dport, :sport].each do |param|
-      it "#{param} should be an array" do
-        @resource[param].class.should == Array
+  describe 'when working out general_args' do
+    HASH_TO_ARGS.each do |test_name,data|
+      describe "for test data '#{test_name}'" do
+        let(:resource) { Puppet::Type.type(:firewall).new(data[:params]) }
+        let(:provider) { Puppet::Type.type(:firewall).provider(:iptables) }
+        let(:instance) { provider.new(resource) }
+
+        it 'general_args should be valid' do
+          instance.general_args.flatten.should == data[:args]
+        end
       end
     end
   end
 
   describe 'when converting rules without comments to resources' do
-    before :each do
-      @rule = '-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061, 7062 -j ACCEPT'
-      @resource = @provider.rule_to_hash(@rule, 'filter', 0)
-      @instance = @provider.new(@resource)
-    end
+    let(:sample_rule) {
+      '-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061, 7062 -j ACCEPT'
+    }
+    let(:resource) { provider.rule_to_hash(sample_rule, 'filter', 0) }
+    let(:instance) { provider.new(resource) }
 
     it 'rule name contains a MD5 sum of the line' do
-      @resource[:name].should == "9999 #{Digest::MD5.hexdigest(@resource[:line])}"
+      resource[:name].should == "9999 #{Digest::MD5.hexdigest(resource[:line])}"
     end
   end
 
   describe 'when creating resources' do
+    let(:instance) { provider.new(resource) }
+
     before :each do
-      @instance = @provider.new(@resource)
-      @provider.expects(:execute).with(['/sbin/iptables-save']).returns("")
+      provider.expects(:execute).with(['/sbin/iptables-save']).returns("")
     end
 
     it 'insert_args should be an array' do
-      @instance.insert_args.class.should == Array
+      instance.insert_args.class.should == Array
     end
   end
 
   describe 'when modifying resources' do
+    let(:instance) { provider.new(resource) }
+
     before :each do
-      @instance = @provider.new(@resource)
-      @provider.expects(:execute).with(['/sbin/iptables-save']).returns ""
+      provider.expects(:execute).with(['/sbin/iptables-save']).returns ""
     end
 
     it 'update_args should be an array' do
-      @instance.update_args.class.should == Array
+      instance.update_args.class.should == Array
     end
   end
 
   describe 'when deleting resources' do
-    before :each do
-      @rule = '-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061, 7062 -j ACCEPT'
-      @resource = @provider.rule_to_hash(@rule, 'filter', 0)
-      @instance = @provider.new(@resource)
-    end
+    let(:sample_rule) {
+      '-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061, 7062 -j ACCEPT'
+    }
+    let(:resource) { provider.rule_to_hash(sample_rule, 'filter', 0) }
+    let(:instance) { provider.new(resource) }
 
     it 'resource[:line] looks like the original rule' do
-      @resource[:line] == @rule
+      resource[:line] == sample_rule
     end
 
     it 'delete_args is an array' do
-      @instance.delete_args.class.should == Array
+      instance.delete_args.class.should == Array
     end
 
     it 'delete_args is the same as the rule string when joined' do
-      @instance.delete_args.join(' ').should == @rule.gsub(/\-A/, '-D')
+      instance.delete_args.join(' ').should == sample_rule.gsub(/\-A/, '-D')
     end
   end
 end


### PR DESCRIPTION
(#9362) Create action property and perform transformation for accept, drop, reject value for iptables jump parameter.

This commit introduces the new 'action' parameter which is designed to designate
the action to take when a match succeeds. This is a cross-platform parameter and
for the values 'accept','drop','reject' it will take the place of the existing
jump parameter.

The jump parameter is deemed as an iptables specific parameter so by splitting
out this parameter for common actions it allows us to extend the firewall resource
to include other providers much more easily in the future. By having such a common
parameter we will be able to compare resources between boxes that may have different
firewall implementations.

The new behaviour is to force the usage for action parameter, and using 'accept',
'drop' or 'reject' for jump will now no longer work.

To aid in the testing of this new property I've added new ways to test converting
iptables rules to hashes and hashes to general_args. This should simplify the
testing of new bugs as well.
