### PR TITLE
(#10263) Fix tests on Puppet 2.6.x

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,7 +54,13 @@ RSpec.configure do |config|
     Puppet.settings[:bindaddress] = "127.0.0.1"
 
     @logs = []
-    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
+    # This tests allows the spec_helper to be >2.6.7 and >2.7.1 compatible
+    # as the Puppet::Test::LogCollector facility wasn't available until 2.7.x
+    if Puppet.const_defined?("Test") and Puppet::Test.const_defined?("LogCollector")
+      Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(@logs))
+    else
+      Puppet::Util::Log.newdestination(@logs)
+    end
 
     @log_level = Puppet::Util::Log.level
   end


### PR DESCRIPTION
Due to the lack of Puppet::Test::LogCollector class, tests fail on puppet
2.6.x. Instead of just using the class, I'm testing its existance first
and only using it if it exists. Otherwise, I'm going to fall back to 2.6.x
methodology.

This seems to make tests work on 2.6.7 (and up) and 2.7.1 (and up) which is
sufficient for now.
