### PR TITLE
(#10295) Work around bug #4248 whereby the puppet/util paths are not bein

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,16 +50,22 @@ Then run the module tool:
 
     puppet-module install puppetlabs-firewall
 
-Depending on the version of Puppet, you may need to restart the 
-puppetmasterd (or Apache) process before this module will work.
-
 This module uses both Ruby based providers so your Puppet configuration
 (ie. puppet.conf) must include the following items:
 
     [agent]
     pluginsync = true
-    
-The module will not operate normally without these features enabled.
+
+The module will not operate normally without these features enabled for the
+client.
+
+If you are using environments or with certain versions of Puppet you may
+need to run Puppet on the master first:
+
+    puppet agent -t --pluginsync --environment production
+
+You may also need to restart Apache, although this shouldn't always be the
+case.
 
 ### Examples
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1,6 +1,15 @@
-# Puppet Firewall type
+# See: #10295 for more details.
+#
+# This is a workaround for bug: #4248 whereby ruby files outside of the normal
+# provider/type path do not load until pluginsync has occured on the puppetmaster
+# 
+# In this case I'm trying the relative path first, then falling back to normal
+# mechanisms. This should be fixed in future versions of puppet but it looks
+# like we'll need to maintain this for some time perhaps.
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..",".."))
 require 'puppet/util/firewall'
 
+# Puppet Firewall type
 Puppet::Type.newtype(:firewall) do
   include Puppet::Util::Firewall
 


### PR DESCRIPTION
(#10295) Work around bug #4248 whereby the puppet/util paths are not being loaded correctly on the puppetmaster

This patch suggested by Dan Carley will work-around the puppet/util error
specified in bug #4248 by loading relative paths instead.

This also fixes the load errors related to running the resource in a standalone
puppet case as well.

If the load fails for some reason, we fall back to the normal load behaviour.
This order is important as we want to load libraries before sync in case the
user has disabled pluginsync in the meantime. This will ensure we attempt to
get the latest copy, but have a fall back just in case.

I believe this fix will need to be applied for some time to support older Puppet
versions.

I've updated the documentation to provide more thorough instructions for
cases where people are using environments, and to tell people to pluginsync
on the master and potentially restart their puppetmaster first just in case.
