### PR TITLE
(#10690) add port property support to ip6tables

### DIFF
--- a/examples/ip6tables/test.pp
+++ b/examples/ip6tables/test.pp
@@ -1,12 +1,12 @@
 firewall { '000 allow foo':
   dport    => [7061, 7062],
-  jump     => 'ACCEPT',
+  action   => accept,
   proto    => 'tcp',
   provider => 'ip6tables'
 }
 
 firewall { '001 allow boo':
-  jump        => 'ACCEPT',
+  action      => accept, 
   iniface     => 'eth0',
   sport       => 123,
   dport       => 123,
@@ -18,27 +18,27 @@ firewall { '001 allow boo':
 firewall { '002 foo':
   dport    => 1233,
   proto    => 'tcp',
-  jump     => 'DROP',
+  action   => drop,
   provider => 'ip6tables'
 }
 
 firewall { '005 INPUT disregard DHCP':
   dport    => ['bootpc', 'bootps'],
-  jump     => 'DROP',
+  action   => drop,
   proto    => 'udp',
   provider => 'ip6tables'
 }
 
 firewall { '006 INPUT disregard netbios':
-  dport    => ['netbios-ns', 'netbios-dgm', 'netbios-ssn'],
-  jump     => 'DROP',
+  port    => ['netbios-ns', 'netbios-dgm', 'netbios-ssn'],
+  action   => drop,
   proto    => 'udp',
   provider => 'ip6tables'
 }
 
 firewall { '006 Disregard CIFS':
   dport    => 'microsoft-ds',
-  jump     => 'DROP',
+  action   => drop,
   proto    => 'tcp',
   provider => 'ip6tables'
 }
@@ -46,59 +46,59 @@ firewall { '006 Disregard CIFS':
 firewall { '010 icmp':
   proto    => 'ipv6-icmp',
   icmp     => 'echo-reply',
-  jump     => 'ACCEPT',
+  action   => accept,
   provider => 'ip6tables'
 }
 
 firewall { '010 INPUT allow loopback':
   iniface  => 'lo',
   chain    => 'INPUT',
-  jump     => 'ACCEPT',
+  action   => accept,
   provider => 'ip6tables'
 }
 
 firewall { '050 INPUT drop invalid':
   state    => 'INVALID',
-  jump     => 'DROP',
+  action   => drop,
   provider => 'ip6tables'
 }
 
 firewall { '051 INPUT allow related and established':
   state    => ['RELATED', 'ESTABLISHED'],
-  jump     => 'ACCEPT',
+  action   => accept,
   provider => 'ip6tables'
 }
 
 firewall { '053 INPUT allow ICMP':
   icmp     => '8',
   proto    => 'ipv6-icmp',
-  jump     => 'ACCEPT',
+  action   => accept,
   provider => 'ip6tables'
 }
 
 firewall { '055 INPUT allow DNS':
   sport    => 'domain',
   proto    => 'udp',
-  jump     => 'ACCEPT',
+  action   => accept,
   provider => 'ip6tables'
 }
 
 firewall { '999 FORWARD drop':
   chain    => 'FORWARD',
-  jump     => 'DROP',
+  action   => drop,
   provider => 'ip6tables'
 }
 
 firewall { '001 OUTPUT allow loopback':
   chain    => 'OUTPUT',
   outiface => 'lo',
-  jump     => 'ACCEPT',
+  action   => accept,
   provider => 'ip6tables'
 }
 
 firewall { '100 OUTPUT drop invalid':
   chain    => 'OUTPUT',
   state    => 'INVALID',
-  jump     => 'DROP',
+  action   => drop,
   provider => 'ip6tables'
 }

--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -27,6 +27,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :log_prefix => "--log-prefix",
     :name => "-m comment --comment",
     :outiface => "-o",
+    :port => '-m multiport --ports',
     :proto => "-p",
     :reject => "--reject-with",
     :source => "-s",
@@ -39,7 +40,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   }
 
   @resource_list = [:table, :source, :destination, :iniface, :outiface, 
-    :proto, :sport, :dport, :name, :state, :icmp, :limit, :burst, :jump, 
+    :proto, :sport, :dport, :port, :name, :state, :icmp, :limit, :burst, :jump, 
     :todest, :tosource, :toports, :log_level, :log_prefix, :reject]
 
 end


### PR DESCRIPTION
Add in missing support for ip6tables.

Ip6tables tests will be coming under another ticket.
