### PR TITLE
(#11443) simple fix of the error message for allowed values of the jump property

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -264,7 +264,7 @@ Puppet::Type.newtype(:firewall) do
 
       if ["accept","reject","drop"].include?(value.downcase)
         raise ArgumentError, <<-EOS
-          Jump destination should not be one of ACCEPT, REJECT or DENY. Use
+          Jump destination should not be one of ACCEPT, REJECT or DROP. Use
           the action property instead.
         EOS
       end


### PR DESCRIPTION
The condition on jump says its allowed accept, reject and drop. Update the error message to say the same thing.
