### PR TITLE
Fix for when iptables-save spews out "FATAL" errors.

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -96,7 +96,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
 
     # String#lines would be nice, but we need to support Ruby 1.8.5
     iptables_save.split("\n").each do |line|
-      unless line =~ /^\#\s+|^\:\S+|^COMMIT/
+      unless line =~ /^\#\s+|^\:\S+|^COMMIT|^FATAL/
         if line =~ /^\*/
           table = line.sub(/\*/, "")
         else

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -68,6 +68,14 @@ describe 'iptables provider' do
     end
   end
 
+  it 'should ignore lines with fatal errors' do
+    provider.expects(:execute).with(['/sbin/iptables-save']).returns(
+"FATAL: Could not load /lib/modules/2.6.18-028stab095.1/modules.dep: No such file or directory"
+)
+
+    provider.instances.length.should == 0
+  end
+
   # Load in ruby hash for test fixtures.
   load 'spec/fixtures/iptables/conversion_hash.rb'
 


### PR DESCRIPTION
On some broken Virtuozzo containers, /lib/modules/$(uname -r)/modules.dep is absent.
This causes iptables-save to give some "FATAL" errors.  This patch fixes the parser
to ignore them instead of generating garbage rules that make for errors in the puppet
agent run.
