### PR TITLE
(#10164) fix ICMP property munging so that 'any' works

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -366,7 +366,9 @@ Puppet::Type.newtype(:firewall) do
 
     munge do |value|
       if value.kind_of?(String)
-        value = @resource.icmp_name_to_number(value)
+        if value != "any"
+          value = @resource.icmp_name_to_number(value)
+        end
       else
         value
       end


### PR DESCRIPTION
Preserve 'any' as a valid type for ICMP rather than converting to a
numberic 255. The iptables rules will return 'any' so keeping it
consistent prevents puppet from thinking its out of sync.
