### PR TITLE
(#12897) validate log_prefix and log_level requires jump => LOG

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -570,6 +570,12 @@ Puppet::Type.newtype(:firewall) do
       end
     end
 
+    if value(:log_prefix) || value(:log_level)
+      unless value(:jump).to_s == "LOG"
+        self.fail "Parameter log_prefix and :log_level require jump => LOG"
+      end
+    end
+
     if value(:burst) && ! value(:limit)
       self.fail "burst makes no sense without limit"
     end


### PR DESCRIPTION
This validates that when log_prefix or log_level is specified the jump should be 'LOG'
