### PR TITLE
(#10665) Add real persistence for iptables 

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -18,6 +18,11 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   commands :iptables      => '/sbin/ip6tables'
   commands :iptables_save => '/sbin/ip6tables-save'
 
+  @persist_command = {
+    :RedHat => %w{/sbin/service ip6tables save},
+    :Debian => %w{/sbin/service iptables-persistent save},
+  }
+
   @resource_map = {
     :burst => "--limit-burst",
     :destination => "-d",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,20 @@
 # Class: firewall
 #
 # Manages the installation of packages for operating systems that are
-#   currently supported by the firewall type.
+# currently supported by the firewall type.
 #
 class firewall {
   if ($::osfamily =~ /^(RedHat|Debian)$/) \
       or ($::operatingsystem =~ /^(RedHat|CentOS|Scientific|Debian|Ubuntu)$/) {
     package { 'iptables':
       ensure => present,
+    }
+
+    if ($::osfamily == 'Debian') \
+        or ($::operatingsystem =~ /^(Debian|Ubuntu)$/) {
+      package { 'iptables-persistent':
+        ensure => present,
+      }
     }
   } else {
     fail('firewall: This OS is not currently supported')


### PR DESCRIPTION
Supports iptables and ip6tables on EL and Debian clones.  Replaces the
previous recommendation of using an Exec resource, which required manual
setup and wasn't able to persist purges of unmanaged rules.

Requires that the `iptables-persistent` package is installed on Deb-alike
machines. This is supported by a new firewall manifest/class.

In most cases it hopes for the `osfamily` fact from Facter >= 1.6.2 but
falls back to an abridged list of `operatingsystem` values.
