### PR TITLE
(#9364) convert netmasks to CIDRs when parsing iptables-save output

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -141,6 +141,13 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
       end
     end
 
+    # convert network masks to cidr
+    # iptables-save on el5 outputs rules using network masks
+    [:source, :destination].each do |prop|
+      next unless hash[prop] =~ /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+      hash[prop] = Puppet::Util::IPCidr.new(hash[prop]).cidr
+    end
+
     # States should always be sorted. This ensures that the output from
     # iptables-save and user supplied resources is consistent.
     hash[:state] = hash[:state].sort unless hash[:state].nil?

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -163,4 +163,20 @@ describe 'iptables provider' do
         '-t filter -D')
     end
   end
+
+  describe 'when converting rules with netmasks to resources' do
+    let(:sample_rule) {
+      '-A INPUT -s 1.1.0.0/255.255.192.0 -d 1.0.0.0/255.128.0.0 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061,7062 -j   ACCEPT'
+    }
+    let(:resource) { provider.rule_to_hash(sample_rule, 'filter', 0) }
+    let(:instance) { provider.new(resource) }
+
+    it 'source contains a cidr netmask' do
+      resource[:source].should == "1.1.0.0/18"
+    end
+
+    it 'destination contains a cidr netmask' do
+      resource[:destination].should == "1.0.0.0/9"
+    end
+  end
 end


### PR DESCRIPTION
iptables-save on centos5/rhel5 outputs IPs using the netmask notation while
puppet expects them to use the CIDR notation. Whitout this fix the rules
are re-applied on every puppet run.
