### PR TITLE
Add support for -m limit on ip6tables

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -40,6 +40,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :toports => "--to-ports",
     :tosource => "--to-source",
     :uid => "-m owner --uid-owner",
+    :limit => "-m limit --limit",
   }
 
   # This is the order of resources as they appear in iptables-save output,


### PR DESCRIPTION
While attempting to replicate a --limit directive from iptables, I found that ip6tables does not accept it.  Added a limit helper to the ip6tables provider to ensure -m limit is passed to the ip6tables command.
