### PR TITLE
Add pkt-type handling

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -50,8 +50,8 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   # we need it to properly parse and apply rules, if the order of resource
   # changes between puppet runs, the changed rules will be re-applied again.
   # This order can be determined by going through iptables source code or just tweaking and trying manually
-  @resource_list = [:table, :pkttype, :source, :destination, :iniface, :outiface,
-    :proto, :gid, :uid, :sport, :dport, :port, :name, :state, :icmp, :limit, :burst, :jump,
+  @resource_list = [:table, :source, :destination, :iniface, :outiface,
+    :proto, :gid, :uid, :sport, :dport, :port, :pkttype, :name, :state, :icmp, :limit, :burst, :jump,
     :todest, :tosource, :toports, :log_level, :log_prefix, :reject]
 
 end

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -59,8 +59,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   # we need it to properly parse and apply rules, if the order of resource
   # changes between puppet runs, the changed rules will be re-applied again.
   # This order can be determined by going through iptables source code or just tweaking and trying manually
-  @resource_list = [:table, :pkttype, :source, :destination, :iniface, :outiface,
-    :proto, :tcp_flags, :gid, :uid, :sport, :dport, :port, :name, :state, :icmp, :limit, :burst,
+  @resource_list = [:table, :source, :destination, :iniface, :outiface,
+    :proto, :tcp_flags, :gid, :uid, :sport, :dport, :port,:pkttype,  :name, :state, :icmp, :limit, :burst,
     :jump, :todest, :tosource, :toports, :log_level, :log_prefix, :reject, :set_mark]
 
   def insert

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -493,12 +493,12 @@ Puppet::Type.newtype(:firewall) do
     desc <<-EOS
       Sets the packet type for traffic.  Allowed values currently are:
 
-      * HOST
-      * BROADCAST
-      * MULTICAST
+      * host
+      * broadcast
+      * multicast
     EOS
 
-    newvalues(:HOST, :BROADCAST, :MULTICAST)
+    newvalues(:host, :broadcast, :multicast)
   end
 
   newparam(:line) do

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -281,12 +281,12 @@ ARGS_TO_HASH = {
       :outiface => 'eth+',
     },
   },
-  'pkttype MULTICAST' => {
-    :line => '-A INPUT -m pkttype --pkt-type MULTICAST -j ACCEPT',
+  'pkttype multicast' => {
+    :line => '-A INPUT -m pkttype --pkt-type multicast -j ACCEPT',
     :table => 'filter',
     :params => {
       :action => 'accept',
-      :pkttype => 'MULTICAST',
+      :pkttype => 'multicast',
     },
   },
 }
@@ -609,8 +609,8 @@ HASH_TO_ARGS = {
       :action => 'accept',
       :chain => 'INPUT',
       :iniface => 'eth0',
-      :pkttype => 'MULTICAST',
+      :pkttype => 'multicast',
     },
-    :args => ["-t", :filter, "-m", "pkttype", "--pkt-type", :MULTICAST, "-i", "eth0", "-p", :tcp, "-m", "comment", "--comment", "062 pkttype multicast", "-j", "ACCEPT"],
+    :args => ["-t", :filter, "-i", "eth0", "-p", :tcp, "-m", "pkttype", "--pkt-type", :multicast, "-m", "comment", "--comment", "062 pkttype multicast", "-j", "ACCEPT"],
   },
 }

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -398,7 +398,7 @@ describe firewall do
   end
 
   describe ':pkttype' do
-    [:MULTICAST, :BROADCAST, :HOST].each do |pkttype|
+    [:multicast, :broadcast, :host].each do |pkttype|
       it "should accept pkttype value #{pkttype}" do
         @resource[:pkttype] = pkttype
         @resource[:pkttype].should == pkttype


### PR DESCRIPTION
I've added this so that we can add multicast rules for pacemaker. I had a terrible time rebasing this so I ended up repatching it on top of a fresh fork of puppetlabs-firewall.  All tests are passing.
