### PR TITLE
(#15038) add gre protocol to list of acceptable protocols

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -209,7 +209,7 @@ Puppet::Type.newtype(:firewall) do
       *tcp*.
     EOS
 
-    newvalues(:tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :all)
+    newvalues(:tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :gre, :all)
     defaultto "tcp"
   end
 

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -74,7 +74,7 @@ describe firewall do
   end
 
   describe ':proto' do
-    [:tcp, :udp, :icmp, :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :all].each do |proto|
+    [:tcp, :udp, :icmp, :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :gre, :all].each do |proto|
       it "should accept proto value #{proto}" do
         @resource[:proto] = proto
         @resource[:proto].should == proto


### PR DESCRIPTION
Add gre protocol to list of acceptable protocols. A resource such as this:

```
firewall { '001 accept gre':
  proto   => 'gre',
  action  => 'accept',
}
```

Was previously thowing an error:

```
Failed to apply catalog: Parameter proto failed: Invalid value "gre". Valid values are tcp, udp, icmp, ipv6-icmp, esp, ah, vrrp, igmp, ipencap, all.  at /etc/puppet/somemanifest.pp:27
```

With my patch applied, the rule gets created correctly:

```
# iptables -L | grep gre
ACCEPT     gre  --  anywhere             anywhere            /* 001 accept gre */ 
```
