### PR TITLE
Rewrite of iptables parser

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -182,7 +182,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
         name = name.gsub(/"/, '')
         hash[:name] = name
       when /--tcp-flags/
-        hash[:tcp_flags] = row[i] + " " + row[i+1]
+        hash[:tcp_flags] = row[i+1] + " " + row[i+2]
         i += 1
       when /!/
         # TODO handle inverse matches


### PR DESCRIPTION
After encountering significant bugs with the iptables parser, I've gone through and rewritten one from scratch which parses left-to-right.  In all my tests so far, every test case which failed previously is working perfectly.

The bugs primarily arise when someone makes a manual change to a server which I wanted Puppet to automatically revert.  Since these manual rules didn't necessarily match the existing supported format, the parser would blow up with very unhelpful output.

Referenced bugs:
- https://projects.puppetlabs.com/issues/15601
- https://projects.puppetlabs.com/issues/15646

Improvements over existing version:
- Rules which have "--sport" instead of "-m multiport --sports" (or similar) are correctly parsed
- Rules with invert matches are detected and can be cleaned up (removed) by resources { "firewall": purge => true }
- Other oddities, such as "-m udp" work, since they're correctly interpreted
- Existing rule generation is unchanged, however the parser ensures the correct fields are populated

Known defects:
- I had a look at adding proper support for invert matching, however that requires significant support from the firewall class, which might not be portable cross platform
- ip6tables hasn't been converted to this new parser... that's a job for another day :)
- Existing issues around comments which don't match the naming policy still apply
- Rules which are matched using the --sport method are not "converted" to the multiport method, however that shouldn't be an issue in most cases since they're functionally identical.  Perhaps we could change the format rules are written in to only use multiport when there are multiple ports?
