### PR TITLE
(#15702) firewall duplicated rules are not removed

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -169,7 +169,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     # Puppet-firewall requires that all rules have comments (resource names) and will fail if
     # a rule in iptables does not have a comment. We get around this by appending a high level
     if ! hash[:name]
-      hash[:name] = "9999 #{Digest::MD5.hexdigest(line)}"
+      hash[:name] = "999#{counter} #{Digest::MD5.hexdigest(line)}"
     end
 
     # Iptables defaults to log_level '4', so it is omitted from the output of iptables-save.


### PR DESCRIPTION
This fix makes sure that every rule has a different name so same rules
get deleted.
