### PR TITLE
rspec 2.11 compatibility

### DIFF
--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -158,11 +158,11 @@ describe firewall do
       end
 
       it "should not accept something invalid for #{port}" do
-        expect { @resource[port] = 'something odd' }.should raise_error(Puppet::Error, /^Parameter .+ failed: Munging failed for value ".+" in class .+: no such service/)
+        expect { @resource[port] = 'something odd' }.to raise_error(Puppet::Error, /^Parameter .+ failed: Munging failed for value ".+" in class .+: no such service/)
       end
 
       it "should not accept something invalid in an array for #{port}" do
-        expect { @resource[port] = ['something odd','something even odder'] }.should raise_error(Puppet::Error, /^Parameter .+ failed: Munging failed for value ".+" in class .+: no such service/)
+        expect { @resource[port] = ['something odd','something even odder'] }.to raise_error(Puppet::Error, /^Parameter .+ failed: Munging failed for value ".+" in class .+: no such service/)
       end
     end
   end
@@ -304,7 +304,7 @@ describe firewall do
           :action => "accept",
           :jump => "custom_chain"
         )
-      }.should raise_error(Puppet::Error, /^Only one of the parameters 'action' and 'jump' can be set$/)
+      }.to raise_error(Puppet::Error, /^Only one of the parameters 'action' and 'jump' can be set$/)
     end
   end
   describe ':gid and :uid' do


### PR DESCRIPTION
Ensure rspec 2.11 compat in provider and type tests and remove unnecessary unit test.
