### PR TITLE
Add missing class declaration

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -112,6 +112,18 @@ So It is recommended that you provide the following in top scope somewhere
       purge => true
     }
 
+You also need to declare the 'my_fw::pre' & 'my_fw::post' classes so that 
+dependencies are satisfied. This can be achieved using an External Node 
+Classifier or the following::
+
+    class { 'my_fw::pre': }
+    class { 'my_fw::post': }
+
+or:
+
+    include my_fw::pre, my_fw:post
+
+
 In this case, it uses classes called 'my_fw::pre' & 'my_fw::post' to define
 default pre and post rules. These rules are required to run in catalog order
 to avoid locking yourself out of your own boxes when Puppet runs, as


### PR DESCRIPTION
README.markdown was missing details about declaring 'my_fw::pre'
and 'my_fw::post' which caused folks following the example to see
the following error:

Could not find dependency Class[My_w::Pre] for Firewall[BLAH]
