### PR TITLE
(#17106) ip6tables provider is still calling the iptables and iptables-save commands

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -109,7 +109,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     counter = 1
 
     # String#lines would be nice, but we need to support Ruby 1.8.5
-    execfail(command(:iptables_save), Puppet::Error).split("\n").each do |line|
+    self.execute([command(:iptables_save)]).split("\n").each do |line|
       unless line =~ /^\#\s+|^\:\S+|^COMMIT|^FATAL/
         if line =~ /^\*/
           table = line.sub(/\*/, "")


### PR DESCRIPTION
This resource was creating the rule in the **_iptables**_ list instead of the **_ip6tables**_ one:

``` puppet
  firewall { '100 allow glusterd on ipv6':
    proto   => 'tcp',
    dport   => '24007',
    action  => accept,
    provider => 'ip6tables',
  }
```

This patch adds support to utilize the commands defined for the specific provider being used.
