### PR TITLE
(#16004) array_matching is contraindicated.

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -469,7 +469,7 @@ Puppet::Type.newtype(:firewall) do
     newvalue(/^\d+$/)
   end
 
-  newproperty(:uid, :array_matching =>:all, :required_features => :owner) do
+  newproperty(:uid, :required_features => :owner) do
     desc <<-EOS
       UID or Username owner matching rule.  Accepts a string argument
       only, as iptables does not accept multiple uid in a single
@@ -477,7 +477,7 @@ Puppet::Type.newtype(:firewall) do
     EOS
   end
 
-  newproperty(:gid, :array_matching =>:all, :required_features => :owner) do
+  newproperty(:gid, :required_features => :owner) do
     desc <<-EOS
       GID or Group owner matching rule.  Accepts a string argument
       only, as iptables does not accept multiple gid in a single

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -310,19 +310,19 @@ describe firewall do
   describe ':gid and :uid' do
     it 'should allow me to set uid' do
       @resource[:uid] = 'root'
-      @resource[:uid].should == ['root']
+      @resource[:uid].should == 'root'
     end
-    it 'should allow me to set uid as an array, breaking iptables' do
+    it 'should allow me to set uid as an array, and silently hide my error' do
       @resource[:uid] = ['root', 'bobby']
-      @resource[:uid].should == ['root', 'bobby']
+      @resource[:uid].should == 'root'
     end
     it 'should allow me to set gid' do
       @resource[:gid] = 'root'
-      @resource[:gid].should == ['root']
+      @resource[:gid].should == 'root'
     end
-    it 'should allow me to set gid as an array, breaking iptables' do
+    it 'should allow me to set gid as an array, and silently hide my error' do
       @resource[:gid] = ['root', 'bobby']
-      @resource[:gid].should == ['root', 'bobby']
+      @resource[:gid].should == 'root'
     end
   end
 


### PR DESCRIPTION
With ":array_matching =>:all", uid/gid rules are reloaded with every
Puppet run.  This is ugly and annoying, and arguably wrong.
