### PR TITLE
Stub iptables save

### DIFF
--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -46,6 +46,7 @@ describe 'iptables provider' do
   before :each do
     Puppet::Type::Firewall.stubs(:defaultprovider).returns provider
     provider.stubs(:command).with(:iptables_save).returns "/sbin/iptables-save"
+    provider.stubs(:execute).with(['/sbin/iptables-save']).returns("")
 
     # Stub iptables version
     Facter.fact(:iptables_version).stubs(:value).returns("1.4.2")


### PR DESCRIPTION
Fix four (two types of) test regressions from PR #102 by always stubbing `iptables-save` content.

See commit messages for more details.

/cc @kbarber
