### PR TITLE
ip6tables provider allways execute /sbin/iptables command

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -17,9 +17,17 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   has_feature :pkttype
 
   optional_commands({
-    :iptables      => '/sbin/ip6tables',
-    :iptables_save => '/sbin/ip6tables-save',
+    :ip6tables      => '/sbin/ip6tables',
+    :ip6tables_save => '/sbin/ip6tables-save',
   })
+
+  def self.iptables(*args)
+    ip6tables(*args)
+  end
+
+  def self.iptables_save(*args)
+    ip6tables_save(*args)
+  end
 
   @resource_map = {
     :burst => "--limit-burst",


### PR DESCRIPTION
OS: CentOS 6.3
Puppet: 3.0.2
Ruby: 1.8.7

I think because optional_commands check iptables method has definded at iptables prodider, so ip6tables provider not define iptables method again.
