### PR TITLE
Fix error reporting for insane hostnames.

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -97,7 +97,11 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     munge do |value|
-      @resource.host_to_ip(value)
+      begin
+        @resource.host_to_ip(value)
+      rescue Exception => e
+        self.fail("host_to_ip failed for #{value}, exception #{e}")
+      end
     end
   end
 


### PR DESCRIPTION
If you put some really silly values in (e.g. /) into hostnames then
the error message s super super cryptic.

This patch fixes that, so it's at least obvious what / where / why it's
failing if you use --trace --debug
