### PR TITLE
Fix external data in firewall port numbers.

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -132,6 +132,9 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     munge do |value|
+      if value.kind_of? Fixnum
+        value = value.to_s
+      end
       @resource.string_to_port(value, :proto)
     end
 


### PR DESCRIPTION
If you use hiera, and hieradata contains port numbers which are unquoted,
then they'll get read in as fixnums (using the YAML backend, which just
don't work.

Ergo add some type conversion where it's needed to stop things from
blowing up with unhelpful errors, such as:

err: Failed to apply catalog: Parameter sport failed: Munging failed for value 9000 in class sport: can't convert Fixnum into String

It could be reasonably argued that this change should be pushed lower,
i.e. that the string_to_port method should call .to_s on anything that
wasn't KindOf(String), as that would be a more generic fix..
