### PR TITLE
(GH-134) Autorequire iptables related packages

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -16,9 +16,16 @@ Puppet::Type.newtype(:firewall) do
     This type provides the capability to manage firewall rules within
     puppet.
 
-    **Autorequires:** If Puppet is managing the iptables or ip6tables chains
-    specified in the `chain` or `jump` parameters, the firewall resource
-    will autorequire those firewallchain resources.
+    **Autorequires:**
+
+    If Puppet is managing the iptables or ip6tables chains specified in the
+    `chain` or `jump` parameters, the firewall resource will autorequire
+    those firewallchain resources.
+
+    If Puppet is managing the iptables or iptables-persistent packages, and
+    the provider is iptables or ip6tables, the firewall resource will
+    autorequire those packages to ensure that any required binaries are
+    installed.
   EOS
 
   feature :rate_limiting, "Rate limiting features."
@@ -567,6 +574,17 @@ Puppet::Type.newtype(:firewall) do
     end
 
     reqs
+  end
+
+  # Classes would be a better abstraction, pending:
+  # http://projects.puppetlabs.com/issues/19001
+  autorequire(:package) do
+    case value(:provider)
+    when :iptables, :ip6tables
+      %w{iptables iptables-persistent}
+    else
+      []
+    end
   end
 
   validate do

--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -16,6 +16,11 @@ Puppet::Type.newtype(:firewallchain) do
     Currently this supports only iptables, ip6tables and ebtables on Linux. And
     provides support for setting the default policy on chains and tables that
     allow it.
+
+    **Autorequires:**
+    If Puppet is managing the iptables or iptables-persistent packages, and
+    the provider is iptables_chain, the firewall resource will autorequire
+    those packages to ensure that any required binaries are installed.
   EOS
 
   feature :iptables_chain, "The provider provides iptables chain features."
@@ -97,6 +102,17 @@ Puppet::Type.newtype(:firewallchain) do
       else
         nil
       end
+    end
+  end
+
+  # Classes would be a better abstraction, pending:
+  # http://projects.puppetlabs.com/issues/19001
+  autorequire(:package) do
+    case value(:provider)
+    when :iptables_chain
+      %w{iptables iptables-persistent}
+    else
+      []
     end
   end
 

--- a/spec/unit/puppet/type/firewallchain_spec.rb
+++ b/spec/unit/puppet/type/firewallchain_spec.rb
@@ -104,4 +104,33 @@ describe firewallchain do
 
   end
 
+  describe 'autorequire packages' do
+    it "provider iptables_chain should autorequire package iptables" do
+      resource[:provider].should == :iptables_chain
+      package = Puppet::Type.type(:package).new(:name => 'iptables')
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource resource
+      catalog.add_resource package
+      rel = resource.autorequire[0]
+      rel.source.ref.should == package.ref
+      rel.target.ref.should == resource.ref
+    end
+
+    it "provider iptables_chain should autorequire packages iptables and iptables-persistent" do
+      resource[:provider].should == :iptables_chain
+      packages = [
+        Puppet::Type.type(:package).new(:name => 'iptables'),
+        Puppet::Type.type(:package).new(:name => 'iptables-persistent')
+      ]
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource resource
+      packages.each do |package|
+        catalog.add_resource package
+      end
+      packages.zip(resource.autorequire) do |package, rel|
+        rel.source.ref.should == package.ref
+        rel.target.ref.should == resource.ref
+      end
+    end
+  end
 end


### PR DESCRIPTION
autorequires from firewall and firewallchain resources to iptables and
iptables-persistent packages, when the appropriate provider is selected and
the packages are managed in the catalog. This will prevent failed rule
creation and persistence on fresh nodes where the packages may not be
pre-installed.
