### PR TITLE
(GH-129) Replace errant return in autoreq block

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -559,18 +559,20 @@ Puppet::Type.newtype(:firewall) do
   end
 
   autorequire(:firewallchain) do
+    reqs = []
+    protocol = nil
+
     case value(:provider)
     when :iptables
       protocol = "IPv4"
     when :ip6tables
       protocol = "IPv6"
-    else
-      return
     end
 
-    reqs = []
-    [value(:chain), value(:jump)].each do |chain|
-      reqs << "#{chain}:#{value(:table)}:#{protocol}" unless chain.nil?
+    unless protocol.nil?
+      [value(:chain), value(:jump)].each do |chain|
+        reqs << "#{chain}:#{value(:table)}:#{protocol}" unless chain.nil?
+      end
     end
 
     reqs


### PR DESCRIPTION
It's not valid to use `return` within a block. We could use `next []`,
however it's probably better form to just always return the array, whether
it's populated or not. This will stop the error:

```
err: Got an uncaught exception of type LocalJumpError: unexpected return
```

When one of the listed providers isn't selected. Which is suitable, because
this autorequire won't be suitable to any other future providers anyway.
