### PR TITLE
(20096) Support systemd on Fedora 15 and up

### DIFF
--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -152,6 +152,11 @@ module Puppet::Util::Firewall
       end
     end
 
+    # Fedora 15 and newer use systemd for to persist iptable rules
+    if os_key == 'RedHat' && Facter.value(:operatingsystem) == 'Fedora' && Facter.value(:operatingsystemrelease).to_i >= 15
+      os_key = 'Fedora'
+    end
+
     cmd = case os_key.to_sym
     when :RedHat
       case proto.to_sym
@@ -159,6 +164,13 @@ module Puppet::Util::Firewall
         %w{/sbin/service iptables save}
       when :IPv6
         %w{/sbin/service ip6tables save}
+      end
+    when :Fedora
+      case proto.to_sym
+      when :IPv4
+        %w{/usr/libexec/iptables.init save}
+      when :IPv6
+        %w{/usr/libexec/ip6tables.init save}
       end
     when :Debian
       case proto.to_sym

--- a/spec/unit/puppet/util/firewall_spec.rb
+++ b/spec/unit/puppet/util/firewall_spec.rb
@@ -97,7 +97,18 @@ describe 'Puppet::Util::Firewall' do
 
       it 'should exec for RedHat identified from osfamily' do
         Facter.fact(:osfamily).stubs(:value).returns('RedHat')
+        Facter.fact(:operatingsystem).stubs(:value).returns('RedHat')
+
         subject.expects(:execute).with(%w{/sbin/service iptables save})
+        subject.persist_iptables(proto)
+      end
+
+      it 'should exec for systemd if running Fedora 15 or greater' do
+        Facter.fact(:osfamily).stubs(:value).returns('RedHat')
+        Facter.fact(:operatingsystem).stubs(:value).returns('Fedora')
+        Facter.fact(:operatingsystemrelease).stubs(:value).returns('15')
+
+        subject.expects(:execute).with(%w{/usr/libexec/iptables.init save})
         subject.persist_iptables(proto)
       end
 
@@ -110,6 +121,8 @@ describe 'Puppet::Util::Firewall' do
 
       it 'should raise a warning when exec fails' do
         Facter.fact(:osfamily).stubs(:value).returns('RedHat')
+        Facter.fact(:operatingsystem).stubs(:value).returns('RedHat')
+
         subject.expects(:execute).with(%w{/sbin/service iptables save}).
           raises(Puppet::ExecutionFailure, 'some error')
         subject.expects(:warning).with('Unable to persist firewall rules: some error')


### PR DESCRIPTION
Add a check to see if running Fedora 15 in order to use init scripts
provided by systemd. This adds compatibility for systemd on Fedora,
which currently returns an incorrect failure message when persisting
rules.
