### PR TITLE
Error reporting fix

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -115,7 +115,11 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     munge do |value|
-      @resource.host_to_ip(value)
+      begin
+        @resource.host_to_ip(value)
+      rescue Exception => e
+        self.fail("host_to_ip failed for #{value}, exception #{e}")
+      end
     end
   end
 


### PR DESCRIPTION
Originally https://github.com/puppetlabs/puppetlabs-firewall/pull/131

I've fixed so that it works for both source and destination.

I don't see how this doesn't work for ip6tables, as the same function is used for ipv4 and ipv6, so I don't understand?
