### PR TITLE
NEEDS_REBASE: Add ipv6 fragmentation matchers and generify known_boolean handling.

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -15,6 +15,9 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   has_feature :mark
   has_feature :tcp_flags
   has_feature :pkttype
+  has_feature :ishasmorefrags6
+  has_feature :islastfrag6
+  has_feature :isfirstfrag6
 
   optional_commands({
     :ip6tables      => '/sbin/ip6tables',
@@ -55,7 +58,10 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :toports => "--to-ports",
     :tosource => "--to-source",
     :uid => "-m owner --uid-owner",
-    :pkttype => "-m pkttype --pkt-type"
+    :pkttype => "-m pkttype --pkt-type",
+    :ishasmorefrags6 => "-m frag --fragmore",
+    :islastfrag6 => "-m frag --fraglast",
+    :isfirstfrag6 => "-m frag --fragfirst",
   }
 
   # Create property methods dynamically
@@ -73,8 +79,15 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   # we need it to properly parse and apply rules, if the order of resource
   # changes between puppet runs, the changed rules will be re-applied again.
   # This order can be determined by going through iptables source code or just tweaking and trying manually
+  # (Note: on my CentOS 6.4 ip6tables-save returns -m frag on the place
+  # I put it when calling the command. So compability with manual changes
+  # not provided with current parser [georg.koester])
   @resource_list = [:table, :source, :destination, :iniface, :outiface,
-    :proto, :gid, :uid, :sport, :dport, :port, :pkttype, :name, :state, :icmp, :limit, :burst, :jump,
+    :proto, :ishasmorefrags6, :islastfrag6, :isfirstfrag6, :gid, :uid, :sport, :dport, :port, :pkttype, :name, :state, :icmp, :limit, :burst, :jump,
     :todest, :tosource, :toports, :log_level, :log_prefix, :reject]
+
+  # These are known booleans that do not take a value, but we want to munge
+  # to true if they exist.
+  @known_booleans = [:ishasmorefrags6, :islastfrag6, :isfirstfrag6]
 
 end

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -42,6 +42,10 @@ Puppet::Type.newtype(:firewall) do
   feature :tcp_flags, "The ability to match on particular TCP flag settings"
   feature :pkttype, "Match a packet type"
   feature :socket, "Match open sockets"
+  feature :ishasmorefrags6, "Match a non-last fragment of a fragmented ipv6 packet - might be first"
+  feature :islastfrag6, "Match the last fragment of an ipv6 packet"
+  feature :isfirstfrag6, "Match the first fragment of a fragmented ipv6 packet"
+
 
   # provider specific features
   feature :iptables, "The provider provides iptables features."
@@ -547,6 +551,31 @@ Puppet::Type.newtype(:firewall) do
     desc <<-EOS
       If true, matches if an open socket can be found by doing a coket lookup
       on the packet.
+    EOS
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:ishasmorefrags6, :required_features => :ishasmorefrags6) do
+    desc <<-EOS
+      If true, matches if the packet has it's 'more fragments' bit set. ipv6.
+    EOS
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:islastfrag6, :required_features => :islastfrag6) do
+    desc <<-EOS
+      If true, matches if the packet is the last fragment. ipv6.
+    EOS
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:isfirstfrag6, :required_features => :isfirstfrag6) do
+    desc <<-EOS
+      If true, matches if the packet is the first fragment. 
+      Sadly cannot be negated. ipv6.
     EOS
 
     newvalues(:true, :false)

--- a/spec/fixtures/ip6tables/conversion_hash.rb
+++ b/spec/fixtures/ip6tables/conversion_hash.rb
@@ -1,0 +1,98 @@
+# These hashes allow us to iterate across a series of test data
+# creating rspec examples for each parameter to ensure the input :line
+# extrapolates to the desired value for the parameter in question. And
+# vice-versa
+
+# This hash is for testing a line conversion to a hash of parameters
+# which will be used to create a resource.
+ARGS_TO_HASH6 = {
+  'source_destination_ipv6_no_cidr' => {
+    :line => '-A INPUT -s 2001:db8:85a3::8a2e:370:7334 -d 2001:db8:85a3::8a2e:370:7334 -m comment --comment "000 source destination ipv6 no cidr"',
+    :table => 'filter',
+    :provider => 'ip6tables',
+    :params => {
+      :source => '2001:db8:85a3::8a2e:370:7334/128',
+      :destination => '2001:db8:85a3::8a2e:370:7334/128',
+    },
+  },
+  'source_destination_ipv6_netmask' => {
+    :line => '-A INPUT -s 2001:db8:1234::/ffff:ffff:ffff:0000:0000:0000:0000:0000 -d 2001:db8:4321::/ffff:ffff:ffff:0000:0000:0000:0000:0000 -m comment --comment "000 source destination ipv6 netmask"',
+    :table => 'filter',
+    :provider => 'ip6tables',
+    :params => {
+      :source => '2001:db8:1234::/48',
+      :destination => '2001:db8:4321::/48',
+    },
+  },
+}
+
+# This hash is for testing converting a hash to an argument line.
+HASH_TO_ARGS6 = {
+  'zero_prefixlen_ipv6' => {
+    :params => {
+      :name => '100 zero prefix length ipv6',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '::/0',
+      :destination => '::/0',
+    },
+    :args => ['-t', :filter, '-p', :tcp, '-m', 'comment', '--comment', '100 zero prefix length ipv6'],
+  },
+  'source_destination_ipv4_no_cidr' => {
+    :params => {
+      :name => '000 source destination ipv4 no cidr',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '1.1.1.1',
+      :destination => '2.2.2.2',
+    },
+    :args => ['-t', :filter, '-s', '1.1.1.1/32', '-d', '2.2.2.2/32', '-p', :tcp, '-m', 'comment', '--comment', '000 source destination ipv4 no cidr'],
+  },
+ 'source_destination_ipv6_no_cidr' => {
+    :params => {
+      :name => '000 source destination ipv6 no cidr',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '2001:db8:1234::',
+      :destination => '2001:db8:4321::',
+    },
+    :args => ['-t', :filter, '-s', '2001:db8:1234::/128', '-d', '2001:db8:4321::/128', '-p', :tcp, '-m', 'comment', '--comment', '000 source destination ipv6 no cidr'],
+  },
+ 'source_destination_ipv6_netmask' => {
+    :params => {
+      :name => '000 source destination ipv6 netmask',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '2001:db8:1234::/ffff:ffff:ffff:0000:0000:0000:0000:0000',
+      :destination => '2001:db8:4321::/ffff:ffff:ffff:0000:0000:0000:0000:0000',
+    },
+    :args => ['-t', :filter, '-s', '2001:db8:1234::/48', '-d', '2001:db8:4321::/48', '-p', :tcp, '-m', 'comment', '--comment', '000 source destination ipv6 netmask'],
+  },
+  'frag_ishasmorefrags' => {
+    :params => {
+      :name => "100 has more fragments",
+      :ishasmorefrags6 => true,
+      :provider => 'ip6tables',
+      :table => "filter",
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "frag", "--fragmore", "-m", "comment", "--comment", "100 has more fragments"],
+  },
+  'frag_islastfrag' => {
+    :params => {
+      :name => "100 last fragment",
+      :islastfrag6 => true,
+      :provider => 'ip6tables',
+      :table => "filter",
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "frag", "--fraglast", "-m", "comment", "--comment", "100 last fragment"],
+  },
+  'frag_isfirstfrags' => {
+    :params => {
+      :name => "100 first fragment",
+      :isfirstfrag6 => true,
+      :provider => 'ip6tables',
+      :table => "filter",
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "frag", "--fragfirst", "-m", "comment", "--comment", "100 first fragment"],
+  },
+}

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -157,3 +157,80 @@ describe 'iptables provider' do
     end
   end
 end
+
+describe 'ip6tables provider' do
+  let(:provider6) { Puppet::Type.type(:firewall).provider(:ip6tables) }
+  let(:resource) {
+    Puppet::Type.type(:firewall).new({
+      :name  => '000 test foo',
+      :action  => 'accept',
+      :provider => "ip6tables",
+    })
+  }
+
+  before :each do
+    Puppet::Type::Firewall.stubs(:ip6tables).returns provider6
+    provider6.stubs(:command).with(:ip6tables_save).returns "/sbin/ip6tables-save"
+
+    # Stub iptables version
+    Facter.fact(:ip6tables_version).stubs(:value).returns("1.4.7")
+
+    Puppet::Util::Execution.stubs(:execute).returns ""
+    Puppet::Util.stubs(:which).with("/sbin/ip6tables-save").
+      returns "/sbin/ip6tables-save"
+  end
+
+  it 'should be able to get a list of existing rules' do
+    provider6.instances.each do |rule|
+      rule.should be_instance_of(provider6)
+      rule.properties[:provider6].to_s.should == provider6.name.to_s
+    end
+  end
+
+  it 'should ignore lines with fatal errors' do
+    Puppet::Util::Execution.stubs(:execute).with(['/sbin/ip6tables-save']).
+      returns("FATAL: Could not load /lib/modules/2.6.18-028stab095.1/modules.dep: No such file or directory")
+
+    provider6.instances.length.should == 0
+  end
+
+  # Load in ruby hash for test fixtures.
+  load 'spec/fixtures/ip6tables/conversion_hash.rb'
+
+  describe 'when converting rules to resources' do
+    ARGS_TO_HASH6.each do |test_name,data|
+      describe "for test data '#{test_name}'" do
+        let(:resource) { provider6.rule_to_hash(data[:line], data[:table], 0) }
+
+        # If this option is enabled, make sure the parameters exactly match
+        if data[:compare_all] then
+          it "the parameter hash keys should be the same as returned by rules_to_hash" do
+            resource.keys.should =~ data[:params].keys
+          end
+        end
+
+        # Iterate across each parameter, creating an example for comparison
+        data[:params].each do |param_name, param_value|
+          it "the parameter '#{param_name.to_s}' should match #{param_value.inspect}" do
+            resource[param_name].should == data[:params][param_name]
+          end
+        end
+      end
+    end
+  end
+
+  describe 'when working out general_args' do
+    HASH_TO_ARGS6.each do |test_name,data|
+      describe "for test data '#{test_name}'" do
+        let(:resource) { Puppet::Type.type(:firewall).new(data[:params]) }
+        let(:provider6) { Puppet::Type.type(:firewall).provider(:ip6tables) }
+        let(:instance) { provider6.new(resource) }
+
+        it 'general_args should be valid' do
+          instance.general_args.flatten.should == data[:args]
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Adds tests for ipv6, too.

ip6tables handles fragmentation differently. There's a special
module and a couple of matchers which are all needed to
implement a stateless firewall correctly.

known_boolean handling with etc has been generified.
The known_boolean functionality was partly tailored
to the :socket feature.
