### PR TITLE
Ensure all services have 'hasstatus => true' for Puppet 2.6

### DIFF
--- a/manifests/linux/archlinux.pp
+++ b/manifests/linux/archlinux.pp
@@ -5,11 +5,13 @@ class firewall::linux::archlinux (
   service { 'iptables':
     ensure => $ensure,
     enable => $enable,
+    hasstatus => true,
   }
 
   service { 'ip6tables':
     ensure => $ensure,
     enable => $enable,
+    hasstatus => true,
   }
 
   file { '/etc/iptables/iptables.rules':

--- a/manifests/linux/debian.pp
+++ b/manifests/linux/debian.pp
@@ -19,8 +19,9 @@ class firewall::linux::debian (
     # This isn't a real service/daemon. The start action loads rules, so just
     # needs to be called on system boot.
     service { 'iptables-persistent':
-      ensure  => undef,
-      enable  => $enable,
+      ensure => undef,
+      enable => $enable,
+      hasstatus => true,
       require => Package['iptables-persistent'],
     }
   }

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -5,5 +5,6 @@ class firewall::linux::redhat (
   service { 'iptables':
     ensure => $ensure,
     enable => $enable,
+    hasstatus => true,
   }
 }


### PR DESCRIPTION
We were getting reports of idempotency issues with 2.6, due to missing
hasstatus setting.

Signed-off-by: Ken Barber ken@bob.sh
