### PR TITLE
Allow the negation of source and destination addresses

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -106,7 +106,12 @@ Puppet::Type.newtype(:firewall) do
 
     munge do |value|
       begin
-        @resource.host_to_ip(value)
+        #ensure ip normalisation works when property negated
+        if value =~ /^! / then
+          @resource.host_to_ip(value.sub(/^! /,'')).sub(/^/,'! ')
+        else
+          @resource.host_to_ip(value)
+        end
       rescue Exception => e
         self.fail("host_to_ip failed for #{value}, exception #{e}")
       end
@@ -124,7 +129,12 @@ Puppet::Type.newtype(:firewall) do
 
     munge do |value|
       begin
-        @resource.host_to_ip(value)
+        #ensure ip normalisation works when property negated
+        if value =~ /^! / then
+          @resource.host_to_ip(value.sub(/^! /,'')).sub(/^/,'! ')
+        else
+          @resource.host_to_ip(value)
+        end
       rescue Exception => e
         self.fail("host_to_ip failed for #{value}, exception #{e}")
       end

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -724,4 +724,28 @@ HASH_TO_ARGS = {
     },
     :args => ['-t', :filter, '-p', :all, '-f', '-m', 'comment', '--comment', '050 isfragment option', '-j', 'ACCEPT'],
   },
+  'destination_negation' => {
+    :params => {
+      :name        => '051 destination negation',
+      :chain       => 'POSTROUTING',
+      :destination => '! 192.168.122.0/24',
+      :jump        => 'MASQUERADE',
+      :proto       => 'all',
+      :source      => '192.168.122.0/24',
+      :table       => 'nat',
+    },
+    :args => ["-t", :nat, "-s", "192.168.122.0/24", "-d", "!", "192.168.122.0/24", "-p", :all, "-m", "comment", "--comment", "051 destination negation", "-j", "MASQUERADE"]
+  },
+    'source_negation' => {
+    :params => {
+      :name        => '051 source negation',
+      :chain       => 'POSTROUTING',
+      :destination => '192.168.122.0/24',
+      :jump        => 'MASQUERADE',
+      :proto       => 'all',
+      :source      => '! 192.168.122.0/24',
+      :table       => 'nat',
+    },
+    :args => ["-t", :nat, "-s", "!", "192.168.122.0/24", "-d", "192.168.122.0/24", "-p", :all, "-m", "comment", "--comment", "051 source negation", "-j", "MASQUERADE"]
+  },
 }


### PR DESCRIPTION
The bulk of this work is allowing IP address normalisation to work while
still maintaining an optional exclamation mark at the beginning of the
parameter.

Usage: put '! ' before the existing destination or source

Example:

  firewall { 'rule name':
    ensure      => 'present',
    chain       => 'POSTROUTING',
    destination => '! 192.168.122.0/24',
    jump        => 'MASQUERADE',
    proto       => 'tcp',
    source      => '192.168.122.0/24',
    table       => 'nat',
    toports     => '1024-65535',
  }

Added some simple spec tests.

This allows the specification of the default rules added by a libvirt installation. Tested on CentOS 5.9, Puppet 2.6.16.

Fixes #125
