### PR TITLE
Gracefully handle when `iptables-save` isn't installed when retrieving instances

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -126,7 +126,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     counter = 1
 
     # String#lines would be nice, but we need to support Ruby 1.8.5
-    iptables_save.split("\n").each do |line|
+    (iptables_save || '').split("\n").each do |line|
       unless line =~ /^\#\s+|^\:\S+|^COMMIT|^FATAL/
         if line =~ /^\*/
           table = line.sub(/\*/, "")


### PR DESCRIPTION
When using this module and purge the resources as documented, e.g.:

``` puppet
resources { 'firewall':
  purge => true,
}
```

You'll see the following error when the `iptables-save` command isn't present:

```
Resources[firewall]: Failed to generate additional resources using 'generate': Command iptables_save is missing
```

This problem stems from the `self.instances` method on the `iptables` provider failing to take into account that the command may not exist and have a `nil` result.
