### PR TITLE
Add ipv6 frag matchers2 and generify known_boolean handling.

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -15,6 +15,9 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   has_feature :mark
   has_feature :tcp_flags
   has_feature :pkttype
+  has_feature :ishasmorefrags
+  has_feature :islastfrag
+  has_feature :isfirstfrag
 
   optional_commands({
     :ip6tables      => 'ip6tables',
@@ -55,7 +58,10 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :toports => "--to-ports",
     :tosource => "--to-source",
     :uid => "-m owner --uid-owner",
-    :pkttype => "-m pkttype --pkt-type"
+    :pkttype => "-m pkttype --pkt-type",
+    :ishasmorefrags => "-m frag --fragid 0 --fragmore",
+    :islastfrag => "-m frag --fragid 0 --fraglast",
+    :isfirstfrag => "-m frag --fragid 0 --fragfirst",
   }
 
   # Create property methods dynamically
@@ -73,8 +79,15 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   # we need it to properly parse and apply rules, if the order of resource
   # changes between puppet runs, the changed rules will be re-applied again.
   # This order can be determined by going through iptables source code or just tweaking and trying manually
+  # (Note: on my CentOS 6.4 ip6tables-save returns -m frag on the place
+  # I put it when calling the command. So compability with manual changes
+  # not provided with current parser [georg.koester])
   @resource_list = [:table, :source, :destination, :iniface, :outiface,
-    :proto, :gid, :uid, :sport, :dport, :port, :pkttype, :name, :state, :icmp, :limit, :burst, :jump,
+    :proto, :ishasmorefrags, :islastfrag, :isfirstfrag, :gid, :uid, :sport, :dport, :port, :pkttype, :name, :state, :icmp, :limit, :burst, :jump,
     :todest, :tosource, :toports, :log_level, :log_prefix, :reject]
+
+  # These are known booleans that do not take a value, but we want to munge
+  # to true if they exist.
+  @known_booleans = [:ishasmorefrags, :islastfrag, :isfirstfrag]
 
 end

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -45,6 +45,9 @@ Puppet::Type.newtype(:firewall) do
   feature :isfragment, "Match fragments"
   feature :address_type, "The ability match on source or destination address type"
   feature :iprange, "The ability match on source or destination IP range "
+  feature :ishasmorefrags, "Match a non-last fragment of a fragmented ipv6 packet - might be first"
+  feature :islastfrag, "Match the last fragment of an ipv6 packet"
+  feature :isfirstfrag, "Match the first fragment of a fragmented ipv6 packet"
 
   # provider specific features
   feature :iptables, "The provider provides iptables features."
@@ -644,6 +647,31 @@ Puppet::Type.newtype(:firewall) do
     desc <<-EOS
       If true, matches if an open socket can be found by doing a coket lookup
       on the packet.
+    EOS
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:ishasmorefrags, :required_features => :ishasmorefrags) do
+    desc <<-EOS
+      If true, matches if the packet has it's 'more fragments' bit set. ipv6.
+    EOS
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:islastfrag, :required_features => :islastfrag) do
+    desc <<-EOS
+      If true, matches if the packet is the last fragment. ipv6.
+    EOS
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:isfirstfrag, :required_features => :isfirstfrag) do
+    desc <<-EOS
+      If true, matches if the packet is the first fragment. 
+      Sadly cannot be negated. ipv6.
     EOS
 
     newvalues(:true, :false)

--- a/spec/fixtures/ip6tables/conversion_hash.rb
+++ b/spec/fixtures/ip6tables/conversion_hash.rb
@@ -1,0 +1,98 @@
+# These hashes allow us to iterate across a series of test data
+# creating rspec examples for each parameter to ensure the input :line
+# extrapolates to the desired value for the parameter in question. And
+# vice-versa
+
+# This hash is for testing a line conversion to a hash of parameters
+# which will be used to create a resource.
+ARGS_TO_HASH6 = {
+  'source_destination_ipv6_no_cidr' => {
+    :line => '-A INPUT -s 2001:db8:85a3::8a2e:370:7334 -d 2001:db8:85a3::8a2e:370:7334 -m comment --comment "000 source destination ipv6 no cidr"',
+    :table => 'filter',
+    :provider => 'ip6tables',
+    :params => {
+      :source => '2001:db8:85a3::8a2e:370:7334/128',
+      :destination => '2001:db8:85a3::8a2e:370:7334/128',
+    },
+  },
+  'source_destination_ipv6_netmask' => {
+    :line => '-A INPUT -s 2001:db8:1234::/ffff:ffff:ffff:0000:0000:0000:0000:0000 -d 2001:db8:4321::/ffff:ffff:ffff:0000:0000:0000:0000:0000 -m comment --comment "000 source destination ipv6 netmask"',
+    :table => 'filter',
+    :provider => 'ip6tables',
+    :params => {
+      :source => '2001:db8:1234::/48',
+      :destination => '2001:db8:4321::/48',
+    },
+  },
+}
+
+# This hash is for testing converting a hash to an argument line.
+HASH_TO_ARGS6 = {
+  'zero_prefixlen_ipv6' => {
+    :params => {
+      :name => '100 zero prefix length ipv6',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '::/0',
+      :destination => '::/0',
+    },
+    :args => ['-t', :filter, '-p', :tcp, '-m', 'comment', '--comment', '100 zero prefix length ipv6'],
+  },
+  'source_destination_ipv4_no_cidr' => {
+    :params => {
+      :name => '000 source destination ipv4 no cidr',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '1.1.1.1',
+      :destination => '2.2.2.2',
+    },
+    :args => ['-t', :filter, '-s', '1.1.1.1/32', '-d', '2.2.2.2/32', '-p', :tcp, '-m', 'comment', '--comment', '000 source destination ipv4 no cidr'],
+  },
+ 'source_destination_ipv6_no_cidr' => {
+    :params => {
+      :name => '000 source destination ipv6 no cidr',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '2001:db8:1234::',
+      :destination => '2001:db8:4321::',
+    },
+    :args => ['-t', :filter, '-s', '2001:db8:1234::/128', '-d', '2001:db8:4321::/128', '-p', :tcp, '-m', 'comment', '--comment', '000 source destination ipv6 no cidr'],
+  },
+ 'source_destination_ipv6_netmask' => {
+    :params => {
+      :name => '000 source destination ipv6 netmask',
+      :table => 'filter',
+      :provider => 'ip6tables',
+      :source => '2001:db8:1234::/ffff:ffff:ffff:0000:0000:0000:0000:0000',
+      :destination => '2001:db8:4321::/ffff:ffff:ffff:0000:0000:0000:0000:0000',
+    },
+    :args => ['-t', :filter, '-s', '2001:db8:1234::/48', '-d', '2001:db8:4321::/48', '-p', :tcp, '-m', 'comment', '--comment', '000 source destination ipv6 netmask'],
+  },
+  'frag_ishasmorefrags' => {
+    :params => {
+      :name => "100 has more fragments",
+      :ishasmorefrags => true,
+      :provider => 'ip6tables',
+      :table => "filter",
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "frag", "--fragid", "0", "--fragmore", "-m", "comment", "--comment", "100 has more fragments"],
+  },
+  'frag_islastfrag' => {
+    :params => {
+      :name => "100 last fragment",
+      :islastfrag => true,
+      :provider => 'ip6tables',
+      :table => "filter",
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "frag", "--fragid", "0", "--fraglast", "-m", "comment", "--comment", "100 last fragment"],
+  },
+  'frag_isfirstfrags' => {
+    :params => {
+      :name => "100 first fragment",
+      :isfirstfrag => true,
+      :provider => 'ip6tables',
+      :table => "filter",
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "frag", "--fragid", "0", "--fragfirst", "-m", "comment", "--comment", "100 first fragment"],
+  },
+}


### PR DESCRIPTION
Adds tests for ipv6, too.

ip6tables handles fragmentation differently. There's a special
module and a couple 'frag' of matchers which are all needed to
implement a stateless firewall correctly.

known_boolean handling has been generified.
Before the known_boolean functionality was partly tailored
to the :socket feature.

(before #165).
