### PR TITLE
Update tests for rspec-system-puppet 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.lock
 # TODO: Ignore this for now until we decide what to do with it
 spec/fixtures/manifests/
 .ruby-version
+.rspec_system

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'puppetlabs_spec_helper', :require => false
-  gem 'rspec-system-puppet', '~>1.2', '>=1.2.0'
+  gem 'rspec-system-puppet', '~>2.0'
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']

--- a/spec/system/basic_spec.rb
+++ b/spec/system/basic_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper_system'
 
 # Here we put the more basic fundamental tests, ultra obvious stuff.
 describe "basic tests:" do
-  it 'make sure we have copied the module across' do
+  context 'make sure we have copied the module across' do
     # No point diagnosing any more if the module wasn't copied properly
-    shell 'ls /etc/puppet/modules/firewall' do |r|
-      r.stdout.should =~ /Modulefile/
-      r.stderr.should be_empty
-      r.exit_code.should be_zero
+    context shell 'ls /etc/puppet/modules/firewall' do
+      its(:stdout) { should =~ /Modulefile/ }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
     end
   end
 end

--- a/spec/system/class_spec.rb
+++ b/spec/system/class_spec.rb
@@ -1,53 +1,39 @@
 require 'spec_helper_system'
 
 describe "firewall class:" do
-  it 'should run successfully' do
+  context 'should run successfully' do
     pp = "class { 'firewall': }"
 
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should_not == 1
-    end
-
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should be_zero
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
     end
   end
 
-  it 'ensure => stopped:' do
-    pp = <<-EOS
-      class { 'firewall':
-        ensure => stopped,
-      }
-    EOS
+  context 'ensure => stopped:' do
+    pp = "class { 'firewall': ensure => stopped }"
 
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should_not == 1
-    end
-
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should be_zero
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
     end
   end
 
-  it 'ensure => running:' do
-    pp = <<-EOS
-      class { 'firewall':
-        ensure => running,
-      }
-    EOS
+  context 'ensure => running:' do
+    pp = "class { 'firewall': ensure => running }"
 
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should_not == 1
-    end
-
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should be_zero
+    context puppet_apply(pp) do |r|
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
     end
   end
 end

--- a/spec/system/params_spec.rb
+++ b/spec/system/params_spec.rb
@@ -21,12 +21,12 @@ firewall { '#{name}':
   end
 
   it 'test various params' do
+    iptables_flush_all_tables
+
     facts = node.facts
 
     unless (facts['operatingsystem'] == 'CentOS') && \
       facts['operatingsystemrelease'] =~ /^5\./ then
-
-      iptables_flush_all_tables
 
       ppm = pp({
         'table' => "'raw'",
@@ -35,13 +35,11 @@ firewall { '#{name}':
         'jump' => 'LOG',
         'log_level' => 'debug',
       })
-      puppet_apply(ppm) do |r|
-        r.stderr.should be_empty
-        r.exit_code.should == 2
-      end
 
-      # check idempotency
       puppet_apply(ppm) do |r|
+        r.exit_code.should == 2
+        r.stderr.should be_empty
+        r.refresh
         r.stderr.should be_empty
         r.exit_code.should be_zero
       end
@@ -58,12 +56,9 @@ firewall { '#{name}':
       'log_level' => 'debug',
     })
     puppet_apply(ppm) do |r|
-      r.stderr.should be_empty
       r.exit_code.should == 2
-    end
-
-    # check idempotency
-    puppet_apply(ppm) do |r|
+      r.stderr.should be_empty
+      r.refresh
       r.stderr.should be_empty
       r.exit_code.should be_zero
     end
@@ -122,11 +117,9 @@ firewall { '#{name}':
     })
 
     puppet_apply(ppm1) do |r|
-      r.stderr.should be_empty
       r.exit_code.should == 2
-    end
-
-    puppet_apply(ppm1) do |r|
+      r.stderr.should be_empty
+      r.refresh
       r.stderr.should be_empty
       r.exit_code.should be_zero
     end

--- a/spec/system/purge_spec.rb
+++ b/spec/system/purge_spec.rb
@@ -1,25 +1,29 @@
 require 'spec_helper_system'
 
 describe "purge tests:" do
-  it 'make sure duplicate existing rules get purged' do
-    iptables_flush_all_tables
+  context 'make sure duplicate existing rules get purged' do
+    before :all do
+      iptables_flush_all_tables
 
-    shell('/sbin/iptables -A INPUT -s 1.2.1.2')
-    shell('/sbin/iptables -A INPUT -s 1.2.1.2')
+      shell('/sbin/iptables -A INPUT -s 1.2.1.2')
+      shell('/sbin/iptables -A INPUT -s 1.2.1.2')
+    end
+
     pp = <<-EOS
 class { 'firewall': }
 resources { 'firewall':
   purge => true,
 }
     EOS
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should == 2
+
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should == 2 }
     end
 
-    system_run('/sbin/iptables-save') do |r|
-      r.stdout.should_not =~ /1\.2\.1\.2/
-      r.stderr.should be_empty
+    context shell('/sbin/iptables-save') do
+      its(:stdout) { should_not =~ /1\.2\.1\.2/ }
+      its(:stderr) { should be_empty }
     end
   end
 end

--- a/spec/system/resource_cmd_spec.rb
+++ b/spec/system/resource_cmd_spec.rb
@@ -4,44 +4,50 @@ require 'spec_helper_system'
 # existing ruleset scenarios. This will give the parsing capabilities of the
 # code a good work out.
 describe 'puppet resource firewall command:' do
-  it 'make sure it returns no errors when executed on a clean machine' do
-    puppet_resource('firewall') do |r|
-      r.exit_code.should be_zero
+  context 'make sure it returns no errors when executed on a clean machine' do
+    context puppet_resource('firewall') do
+      its(:exit_code) { should be_zero }
       # don't check stdout, some boxes come with rules, that is normal
-      r.stderr.should be_empty
+      its(:stderr) { should be_empty }
     end
   end
 
-  it 'flush iptables and make sure it returns nothing afterwards' do
-    iptables_flush_all_tables
+  context 'flush iptables and make sure it returns nothing afterwards' do
+    before :all do
+      iptables_flush_all_tables
+    end
 
     # No rules, means no output thanks. And no errors as well.
-    puppet_resource('firewall') do |r|
-      r.exit_code.should be_zero
-      r.stderr.should be_empty
-      r.stdout.should == "\n"
+    context puppet_resource('firewall') do
+      its(:exit_code) { should be_zero }
+      its(:stderr) { should be_empty }
+      its(:stdout) { should == "\n" }
     end
   end
 
-  it 'accepts rules without comments' do
-    iptables_flush_all_tables
-    shell('/sbin/iptables -A INPUT -j ACCEPT -p tcp --dport 80')
+  context 'accepts rules without comments' do
+    before :all do
+      iptables_flush_all_tables
+      shell('/sbin/iptables -A INPUT -j ACCEPT -p tcp --dport 80')
+    end
 
-    puppet_resource('firewall') do |r|
-      r.exit_code.should be_zero
+    context puppet_resource('firewall') do |r|
+      its(:exit_code) { should be_zero }
       # don't check stdout, testing preexisting rules, output is normal
-      r.stderr.should be_empty
+      its(:stderr) { should be_empty }
     end
   end
 
-  it 'accepts rules with invalid comments' do
-    iptables_flush_all_tables
-    shell('/sbin/iptables -A INPUT -j ACCEPT -p tcp --dport 80 -m comment --comment "http"')
+  context 'accepts rules with invalid comments' do
+    before :all do
+      iptables_flush_all_tables
+      shell('/sbin/iptables -A INPUT -j ACCEPT -p tcp --dport 80 -m comment --comment "http"')
+    end
 
-    puppet_resource('firewall') do |r|
-      r.exit_code.should be_zero
+    context puppet_resource('firewall') do
+      its(:exit_code) { should be_zero }
       # don't check stdout, testing preexisting rules, output is normal
-      r.stderr.should be_empty
+      its(:stderr) { should be_empty }
     end
   end
 end

--- a/spec/system/standard_usage_spec.rb
+++ b/spec/system/standard_usage_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_system'
 
 # Some tests for the standard recommended usage
 describe 'standard usage tests:' do
-  it 'standard 1' do
+  context 'standard 1' do
     pp = <<-EOS
       class my_fw::pre {
         Firewall {
@@ -48,14 +48,12 @@ describe 'standard usage tests:' do
       }
     EOS
 
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should_not == 1
-    end
-
-    puppet_apply(pp) do |r|
-      r.stderr.should be_empty
-      r.exit_code.should be_zero
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
     end
   end
 end


### PR DESCRIPTION
This changes all the tests to be not only compatible with rspec-system-puppet
2, but to use some of the new syntactic sugar it provides.

Signed-off-by: Ken Barber ken@bob.sh
