### PR TITLE
burst causes Puppet to continuously modify the rule

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -247,6 +247,12 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
       hash[:log_level] = '4'
     end
 
+    # Iptables defaults to burst '5', so it is ommitted from the output of iptables-save.
+    # If the :limit value is set and you don't have a burst set, we assume it to be '5'.
+    if hash[:limit] && ! hash[:burst]
+      hash[:burst] = '5'
+    end
+
     hash[:line] = line
     hash[:provider] = self.name.to_s
     hash[:table] = table


### PR DESCRIPTION
OS: Ubuntu 12.04
Puppet: 3.2.1
iptables: 1.4.12-1ubuntu5

Multiple consecutive Puppet runs, notice it keeps updating the '101 LOG' rule:

```
$ puppet apply /etc/puppet/manifests/site.pp
Notice: /Stage[main]/Firewall::Linux::Debian/Package[iptables-persistent]/ensure: ensure changed 'purged' to 'present'
Notice: /Firewallchain[in_log:filter:IPv4]/ensure: created
Notice: /Firewall[025 jump log]/ensure: created
Notice: /Firewall[101 LOG]/ensure: created
Notice: Finished catalog run in 3.03 seconds
$ puppet apply /etc/puppet/manifests/site.pp
Notice: /Firewall[101 LOG]/burst: burst changed '' to '5'
Notice: Firewall[101 LOG](provider=iptables): Properties changed - updating rule
Notice: Finished catalog run in 1.45 seconds
$ puppet apply /etc/puppet/manifests/site.pp
Notice: /Firewall[101 LOG]/burst: burst changed '' to '5'
Notice: Firewall[101 LOG](provider=iptables): Properties changed - updating rule
Notice: Finished catalog run in 1.46 seconds
```

iptables output shows the rule as being configured properly:

```
$ iptables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
in_log     all  --  anywhere             anywhere             /* 025 jump log */

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination

Chain in_log (1 references)
target     prot opt source               destination
LOG        tcp  --  anywhere             anywhere             /* 101 LOG */ limit: avg 5/sec burst 5 LOG level warning prefix "IN-LOG: "
```

test class:

```
# test class, just a test for puppetlabs-firewall
class test {

  # Include the firewall class
  class { 'firewall': }

  # Setup chains
  firewallchain { 'in_log:filter:IPv4':
    ensure  => present,
  }

  # INPUT Chain
  firewall { '025 jump log':
    proto => 'all',
    jump  => 'in_log',
  }

  # in_log Chain
  firewall { '101 LOG':
    chain       => 'in_log',
    jump        => 'LOG',
    limit       => '5/sec',
    burst       => 5,
    log_level   => 'warning',
    log_prefix  => 'IN-LOG: ',
  }

}
```
