### PR TITLE
Add support for --src-type and --dst-type

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   @resource_map = {
     :burst => "--limit-burst",
     :destination => "-d",
-    :destination_type => "-m addrtype --dst-type",
+    :dst_type => "-m addrtype --dst-type",
     :dport => ["-m multiport --dports", "-m (udp|tcp) --dport"],
     :gid => "-m owner --gid-owner",
     :icmp => "-m icmp --icmp-type",
@@ -60,7 +60,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :set_mark => mark_flag,
     :socket => "-m socket",
     :source => "-s",
-    :source_type => "-m addrtype --src-type",
+    :src_type => "-m addrtype --src-type",
     :sport => ["-m multiport --sports", "-m (udp|tcp) --sport"],
     :state => "-m state --state",
     :table => "-t",
@@ -90,7 +90,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   # This order can be determined by going through iptables source code or just tweaking and trying manually
   @resource_list = [:table, :source, :destination, :iniface, :outiface,
     :proto, :isfragment, :tcp_flags, :gid, :uid, :sport, :dport, :port,
-    :destination_type, :source_type, :socket, :pkttype, :name, :state, :icmp,
+    :dst_type, :src_type, :socket, :pkttype, :name, :state, :icmp,
     :limit, :burst, :jump, :todest, :tosource, :toports, :log_prefix,
     :log_level, :reject, :set_mark]
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -222,11 +222,11 @@ Puppet::Type.newtype(:firewall) do
     end
   end
 
-  newproperty(:destination_type, :required_features => :address_type) do
+  newproperty(:dst_type, :required_features => :address_type) do
     desc <<-EOS
       The destination address type. For example:
 
-          destination_type => 'LOCAL'
+          dst_type => 'LOCAL'
 
       Can be one of:
 
@@ -248,11 +248,11 @@ Puppet::Type.newtype(:firewall) do
               :BLACKHOLE, :UNREACHABLE, :PROHIBIT, :THROW, :NAT, :XRESOLVE)
   end
 
-  newproperty(:source_type, :required_features => :address_type) do
+  newproperty(:src_type, :required_features => :address_type) do
     desc <<-EOS
       The source address type. For example:
 
-          source_type => 'LOCAL'
+          src_type => 'LOCAL'
 
       Can be one of:
 

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -117,18 +117,18 @@ ARGS_TO_HASH = {
       :sport => ["15","512-1024"],
     },
   },
-  'destination_type_1' => {
+  'dst_type_1' => {
     :line => '-A INPUT -m addrtype --dst-type LOCAL',
     :table => 'filter',
     :params => {
-      :destination_type => 'LOCAL',
+      :dst_type => 'LOCAL',
     },
   },
-  'source_type_1' => {
+  'src_type_1' => {
     :line => '-A INPUT -m addrtype --src-type LOCAL',
     :table => 'filter',
     :params => {
-      :source_type => 'LOCAL',
+      :src_type => 'LOCAL',
     },
   },
   'tcp_flags_1' => {
@@ -503,21 +503,21 @@ HASH_TO_ARGS = {
     },
     :args => ["-t", :filter, "-p", :tcp, "-m", "multiport", "--dports", "15,512:1024", "-m", "comment", "--comment", "100 sport range"],
   },
-  'destination_type_1' => {
+  'dst_type_1' => {
     :params => {
-      :name => '000 destination_type',
+      :name => '000 dst_type',
       :table => 'filter',
-      :destination_type => 'LOCAL',
+      :dst_type => 'LOCAL',
     },
-    :args => ['-t', :filter, '-p', :tcp, '-m', 'addrtype', '--dst-type', :LOCAL, '-m', 'comment', '--comment', '000 destination_type'],
+    :args => ['-t', :filter, '-p', :tcp, '-m', 'addrtype', '--dst-type', :LOCAL, '-m', 'comment', '--comment', '000 dst_type'],
   },
-  'source_type_1' => {
+  'src_type_1' => {
     :params => {
-      :name => '000 source_type',
+      :name => '000 src_type',
       :table => 'filter',
-      :source_type => 'LOCAL',
+      :src_type => 'LOCAL',
     },
-    :args => ['-t', :filter, '-p', :tcp, '-m', 'addrtype', '--src-type', :LOCAL, '-m', 'comment', '--comment', '000 source_type'],
+    :args => ['-t', :filter, '-p', :tcp, '-m', 'addrtype', '--src-type', :LOCAL, '-m', 'comment', '--comment', '000 src_type'],
   },
   'tcp_flags_1' => {
     :params => {

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -172,7 +172,7 @@ describe firewall do
     end
   end
 
-  [:destination_type, :source_type].each do |addrtype|
+  [:dst_type, :src_type].each do |addrtype|
     describe addrtype do
       it "should have no default" do
         res = @class.new(:name => "000 test")


### PR DESCRIPTION
Add support for filtering by source and destination address types. Supported by
iptables only, this feature allows filtering packets by the address type (such
as whether the packet came from a local address, a broadcast address, a
multicast address, etc).

Adds the `:address_type` feature to allow a provider to declare support for
filtering on the basis of address type.
