### PR TITLE
Rules are purged before all of the new ones are created

### DIFF
--- a/spec/system/purge_spec.rb
+++ b/spec/system/purge_spec.rb
@@ -26,4 +26,67 @@ resources { 'firewall':
       its(:stderr) { should be_empty }
     end
   end
+
+  context 'make sure rules get purged after applying new ones and not before' do
+    before :all do
+      iptables_flush_all_tables
+
+      shell('/sbin/iptables -A INPUT -s 1.2.1.2')
+      shell('/sbin/iptables -A INPUT -s 1.2.1.2')
+    end
+
+    pp = <<-EOS
+      class my_fw::pre {
+        Firewall {
+          require => undef,
+        }
+
+        # Default firewall rules
+        firewall { '000 accept all icmp':
+          proto   => 'icmp',
+          action  => 'accept',
+        }->
+        firewall { '001 accept all to lo interface':
+          proto   => 'all',
+          iniface => 'lo',
+          action  => 'accept',
+        }->
+        firewall { '002 accept related established rules':
+          proto   => 'all',
+          state   => ['RELATED', 'ESTABLISHED'],
+          action  => 'accept',
+        }
+      }
+      class my_fw::post {
+        firewall { '999 drop all':
+          proto   => 'all',
+          action  => 'drop',
+          before  => undef,
+        }
+      }
+      resources { "firewall":
+        purge => true
+      }
+      Firewall {
+        before  => Class['my_fw::post'],
+        require => Class['my_fw::pre'],
+      }
+      class { ['my_fw::pre', 'my_fw::post']: }
+      class { 'firewall': }
+      firewall { '500 open up port 22':
+        action => 'accept',
+        proto => 'tcp',
+        dport => 22,
+      }
+    EOS
+
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should == 2 }
+      it "create rules before purging" do
+        list = subject.stdout.gsub(/.*ensure: (created|removed).*|.*Finished catalog run.*/, "\\1").split("\n")
+        list.should eq(["created", "created", "created", "created", "created", "removed", "removed"]), subject.stdout
+      end
+    end
+  end
 end


### PR DESCRIPTION
I'm having an issue where some wget requests (using wget:fetch definition from maestrodev/wget module) are happening between firewall rules.

Some default rules that are in the CentOS box are deleted, then wget tries to download a file and fails to do dns resolution, then the rest of the firewall rules are applied later on. The second time puppet is run it succeeds

Added a system spec to show the problem and expected behavior

This is the sequence of events in this spec. I would expect to have all firewall rules added before old ones are removed to avoid losing connection to the box or some other network issue

```
   Notice: /Firewall[9002 cf9e8bfd0c6419a489cce21f32abed1e]/ensure: removed
   Notice: /Firewall[000 accept all icmp]/ensure: created
   Notice: /Firewall[9001 cf9e8bfd0c6419a489cce21f32abed1e]/ensure: removed
   Notice: /Firewall[001 accept all to lo interface]/ensure: created
   Notice: /Firewall[002 accept related established rules]/ensure: created
   Notice: /Firewall[500 open up port 22]/ensure: created
   Notice: /Firewall[999 drop all]/ensure: created
   Notice: Finished catalog run in 0.80 seconds
```

I tried to work around by adding some 'before' requirements to firewall. I didn't know how to make all wget::fetch definitions depend on all the firewall definitions, so I tried to make firewall run before Package['wget'] as all wget:fetch definitions require that.

```
  Firewall {
    before  => [Class['maestro_nodes::firewall::post'], Package['wget']],
    require => Class['maestro_nodes::firewall::pre'],
  }
```

```
class maestro_nodes::firewall::post {
   firewall { "999 drop all other requests to ${ipaddress}":
     proto       => 'all',
     action      => 'drop',
     destination => [$ipaddress],
     before      => Package['wget'], # <---------
   }
}
```

```
    resources { 'firewall':
      purge => true,
      before => Package['wget'],
    }
```

But it didn't work
