### PR TITLE
Generate of options to parse in the correct order from @resource_map

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -179,11 +179,26 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     end
 
     ############
+    # Populate parser_list with used value, in the correct order
+    ############
+    map_index={}
+    @resource_map.each_pair do |map_k,map_v|
+      map_v.each do |v|
+        ind=values.index(/\s#{v}/)
+        next unless ind
+        map_index[map_k]=ind
+     end
+    end
+    # Generate parser_list based on the index of the found option
+    parser_list=[]
+    map_index.sort_by{|k,v| v}.each{|mapi| parser_list << mapi.first }
+
+    ############
     # MAIN PARSE
     ############
 
     # Here we iterate across our values to generate an array of keys
-    @resource_list.reverse.each do |k|
+    parser_list.reverse.each do |k|
       resource_map_key = @resource_map[k]
       [resource_map_key].flatten.each do |opt|
         if values.slice!(/\s#{opt}/)


### PR DESCRIPTION
Hi,

when parsing the 'original' iptable configuration on RedHat6, the parser got a bit confused. The ordering of iptables-save may be a bit different than expected.

being able to parse existing iptables rules should make it easier to switch existing servers/scripts to using puppet.
# iptables-save

..
*filter
:INPUT ACCEPT [0:0]
:FORWARD ACCEPT [0:0]
:OUTPUT ACCEPT [24:2432]
-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
-A INPUT -p icmp -j ACCEPT
-A INPUT -i lo -j ACCEPT
-A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT
-A INPUT -j REJECT --reject-with icmp-host-prohibited
-A FORWARD -j REJECT --reject-with icmp-host-prohibited
COMMIT
# puppet resource firewall

...
firewall { '9004 dc0f1adfee77aa04ef7fdf348860a701':
  ensure => 'present',
  action => 'accept',
  chain  => 'INPUT',
  dport  => ['NEW'],
  proto  => 'tcp',
  state  => ['22'],
  table  => 'filter',
}
...
# After patching iptables.rb:

firewall { '9004 dc0f1adfee77aa04ef7fdf348860a701':
  ensure => 'present',
  action => 'accept',
  chain  => 'INPUT',
  dport  => ['22'],
  proto  => 'tcp',
  state  => ['NEW'],
  table  => 'filter',
}

Thanks,
Frank
