### PR TITLE
updated patch to generate parse_list for iptables-save output.

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -183,7 +183,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     ############
     map_index={}
     @resource_map.each_pair do |map_k,map_v|
-      map_v.each do |v|
+      [map_v].flatten.each do |v|
         ind=values.index(/\s#{v}/)
         next unless ind
         map_index[map_k]=ind


### PR DESCRIPTION
Hi,

sorry about that earlier version which broke the tests; I've fixed the code and tested with ruby 1.8.7, 1.9.3 and 2.0.0 and all tests are now successful.

The patch is to make 'puppet resource firewall' properly parse the iptables rules as generated by system-config-firewall-tui.

Thanks,
Frank
