### PR TITLE
No firewallchain autorequire for INPUT, OUTPUT and FORWARD when table is :filter to enable DROP policy without blocking

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -667,8 +667,9 @@ Puppet::Type.newtype(:firewall) do
     end
 
     unless protocol.nil?
+      table = value(:table)
       [value(:chain), value(:jump)].each do |chain|
-        reqs << "#{chain}:#{value(:table)}:#{protocol}" unless chain.nil?
+        reqs << "#{chain}:#{table}:#{protocol}" unless ( chain.nil? || (['INPUT', 'OUTPUT', 'FORWARD'].include?(chain) && table == :filter) )
       end
     end
 


### PR DESCRIPTION
This modification allows to disable autorequire of firewallchain only for the following:
   INPUT:filter:...
   OUTPUT:filter:...
   FORWARD:filter:...

It allows to specify those firewallchains at the end of all firewall rules (in the my_fw::post for example) with a default DROP policy without blocking everything.
