### PR TITLE
Remove redundant `include` call in system spec helper.

### DIFF
--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -36,7 +36,6 @@ RSpec.configure do |c|
 
   # Import in our local helpers
   c.include ::LocalHelpers
-  c.include RSpecSystemPuppet::Helpers
 
   # This is where we 'setup' the nodes before running our tests
   c.before :suite do


### PR DESCRIPTION
`rspec-system-puppet` helpers are already included few lines above the deleted
line, which by the way would have no effect anyway.
