### PR TITLE
add ipsec policy matching

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -24,6 +24,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   has_feature :socket
   has_feature :address_type
   has_feature :iprange
+  has_feature :ipsec_dir
+  has_feature :ipsec_policy
 
   optional_commands({
     :iptables => 'iptables',
@@ -75,6 +77,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :uid => "-m owner --uid-owner",
     :pkttype => "-m pkttype --pkt-type",
     :isfragment => "-f",
+    :ipsec_dir => "-m policy --dir",
+    :ipsec_policy => "--pol",
   }
 
   # These are known booleans that do not take a value, but we want to munge
@@ -99,7 +103,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   # This order can be determined by going through iptables source code or just tweaking and trying manually
   @resource_list = [:table, :source, :src_range, :destination, :dst_range, :iniface, :outiface,
     :proto, :isfragment, :tcp_flags, :gid, :uid, :sport, :dport, :port,
-    :dst_type, :src_type, :socket, :pkttype, :name, :state, :ctstate, :icmp,
+    :dst_type, :src_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy, :state, :ctstate, :icmp,
     :limit, :burst, :jump, :todest, :tosource, :toports, :log_prefix,
     :log_level, :reject, :set_mark]
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -49,6 +49,8 @@ Puppet::Type.newtype(:firewall) do
   feature :ishasmorefrags, "Match a non-last fragment of a fragmented ipv6 packet - might be first"
   feature :islastfrag, "Match the last fragment of an ipv6 packet"
   feature :isfirstfrag, "Match the first fragment of a fragmented ipv6 packet"
+  feature :ipsec_policy, "Match IPsec policy"
+  feature :ipsec_dir, "Match IPsec policy direction"
 
   # provider specific features
   feature :iptables, "The provider provides iptables features."
@@ -716,6 +718,22 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     newvalues(:true, :false)
+  end
+
+  newproperty(:ipsec_policy, :required_features => :ipsec_policy) do
+	  desc <<-EOS
+	  	 Sets the ipsec policy type
+	  EOS
+
+	  newvalues(:none, :ipsec)
+  end
+
+  newproperty(:ipsec_dir, :required_features => :ipsec_dir) do
+	  desc <<-EOS
+	  	 Sets the ipsec policy direction
+	  EOS
+
+	  newvalues(:in, :out)
   end
 
   newparam(:line) do


### PR DESCRIPTION
This adds support for ipsec policy matching.

I've been using this code for over a year now. However the only thing I am not certain about is the order of the parameter on [line 106](https://github.com/phemmer/puppetlabs-firewall/commit/3eb9919fdc8d8c8d98c626aab744af29cc53a9ad#diff-14bcf0413d55d21f486f643f82fce2e7R106). This appears to be the right spot, but that was just determined through trial and error.
