### PR TITLE
Include additional valid ctstate parameters.

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -564,9 +564,12 @@ Puppet::Type.newtype(:firewall) do
       * ESTABLISHED
       * NEW
       * RELATED
+      * UNTRACKED
+      * SNAT
+      * DNAT
     EOS
 
-    newvalues(:INVALID,:ESTABLISHED,:NEW,:RELATED)
+    newvalues(:INVALID,:ESTABLISHED,:NEW,:RELATED,:UNTRACKED,:SNAT,:DNAT)
 
     # States should always be sorted. This normalizes the resource states to
     # keep it consistent with the sorted result from iptables-save.


### PR DESCRIPTION
When the ctstate parameter was added some additional avaliable conntrack states were not added at the same time. I've included them in the check - this gives added flexibility to the firewall module.
