### PR TITLE
Fedora commands needed changed to support the systemctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ spec/fixtures/manifests/
 .rspec_system
 .bundle
 vendor/
+/.project

--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -182,9 +182,9 @@ module Puppet::Util::Firewall
     when :Fedora
       case proto.to_sym
       when :IPv4
-        %w{/usr/libexec/iptables.init save}
+        %w{iptables-save > /etc/sysconfig/iptables}
       when :IPv6
-        %w{/usr/libexec/ip6tables.init save}
+        %w{ip6tables-save > /etc/sysconfig/ip6tables}
       end
     when :Debian
       case proto.to_sym


### PR DESCRIPTION
Fedora no longer contains the old /usr/libexec/iptables.init 
The new systemctl service does not contain support for init either
