### PR TITLE
(MODULES-442) Correct boolean properties behavior

### DIFF
--- a/spec/acceptance/change_source_spec.rb
+++ b/spec/acceptance/change_source_spec.rb
@@ -28,6 +28,11 @@ describe 'firewall type' do
       apply_manifest(pp, :catch_failures => true)
     end
 
+    it 'adds a unmanaged rule without a comment' do
+      shell('/sbin/iptables -A INPUT -t filter -s 8.0.0.3/32 -p tcp -m multiport --ports 102 -j ACCEPT')
+      expect(shell('iptables -S').stdout).to match(/-A INPUT -s 8\.0\.0\.3\/32 -p tcp -m multiport --ports 102 -j ACCEPT/)
+    end
+
     it 'contains the changable 8.0.0.1 rule' do
       shell('iptables -S') do |r|
         expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.1\/32 -p tcp -m multiport --ports 101 -m comment --comment "101 test source changes" -j ACCEPT/)
@@ -37,11 +42,6 @@ describe 'firewall type' do
       shell('iptables -S') do |r|
         expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.2\/32 -p tcp -m multiport --ports 100 -m comment --comment "100 test source static" -j ACCEPT/)
       end
-    end
-
-    it 'adds a unmanaged rule without a comment' do
-      shell('/sbin/iptables -R INPUT 1 -t filter -s 8.0.0.3/32 -p tcp -m multiport --ports 100 -j ACCEPT')
-      expect(shell('iptables -S').stdout).to match(/-A INPUT -s 8\.0\.0\.3\/32 -p tcp -m multiport --ports 100 -j ACCEPT/)
     end
 
     it 'changes to 8.0.0.4 second' do

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -116,6 +116,7 @@ describe 'firewall type' do
         EOS
 
         apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
       end
 
       it 'should contain the rule' do
@@ -138,6 +139,7 @@ describe 'firewall type' do
         EOS
 
         apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
       end
 
       it 'should contain the rule' do
@@ -187,6 +189,7 @@ describe 'firewall type' do
         EOS
 
         apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
       end
 
       it 'should contain the rule' do
@@ -236,6 +239,7 @@ describe 'firewall type' do
         EOS
 
         apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
       end
 
       it 'should contain the rule' do
@@ -258,6 +262,7 @@ describe 'firewall type' do
         EOS
 
         apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
       end
 
       it 'should contain the rule' do
@@ -307,6 +312,7 @@ describe 'firewall type' do
         EOS
 
         apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
       end
 
       it 'should contain the rule' do
@@ -683,6 +689,11 @@ describe 'firewall type' do
   end
 
   describe 'jump' do
+    after :all do
+      iptables_flush_all_tables
+      expect(shell('iptables -t filter -X TEST').stderr).to eq("")
+    end
+
     context 'MARK' do
       it 'applies' do
         pp = <<-EOS

--- a/spec/acceptance/ip6_fragment_spec.rb
+++ b/spec/acceptance/ip6_fragment_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper_acceptance'
+
+describe 'firewall ishasmorefrags/islastfrag/isfirstfrag properties' do
+  before :all do
+    ip6tables_flush_all_tables
+  end
+
+  shared_examples "is idempotent" do |values, line_match|
+    it "changes the values to #{values}" do
+      pp = <<-EOS
+          class { '::firewall': }
+          firewall { '599 - test':
+            ensure   => present,
+            proto    => 'tcp',
+            provider => 'ip6tables',
+            #{values}
+          }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+
+      shell('ip6tables -S') do |r|
+        expect(r.stdout).to match(/#{line_match}/)
+      end
+    end
+  end
+  shared_examples "doesn't change" do |values, line_match|
+    it "doesn't change the values to #{values}" do
+      pp = <<-EOS
+          class { '::firewall': }
+          firewall { '599 - test':
+            ensure   => present,
+            proto    => 'tcp',
+            provider => 'ip6tables',
+            #{values}
+          }
+      EOS
+
+      apply_manifest(pp, :catch_changes => true)
+
+      shell('ip6tables -S') do |r|
+        expect(r.stdout).to match(/#{line_match}/)
+      end
+    end
+  end
+
+  describe 'adding a rule' do
+    context 'when unset' do
+      before :all do
+        ip6tables_flush_all_tables
+      end
+      it_behaves_like 'is idempotent', '', /-A INPUT -p tcp -m comment --comment "599 - test"/
+    end
+    context 'when set to true' do
+      before :all do
+        ip6tables_flush_all_tables
+      end
+      it_behaves_like "is idempotent", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
+    end
+    context 'when set to false' do
+      before :all do
+        ip6tables_flush_all_tables
+      end
+      it_behaves_like "is idempotent", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
+    end
+  end
+  describe 'editing a rule' do
+    context 'when unset or false' do
+      before :each do
+        ip6tables_flush_all_tables
+        shell('/sbin/ip6tables -A INPUT -p tcp -m comment --comment "599 - test"')
+      end
+      context 'and current value is false' do
+        it_behaves_like "doesn't change", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
+      end
+      context 'and current value is true' do
+        it_behaves_like "is idempotent", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
+      end
+    end
+    context 'when set to true' do
+      before :each do
+        ip6tables_flush_all_tables
+        shell('/sbin/ip6tables -A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"')
+      end
+      context 'and current value is false' do
+        it_behaves_like "is idempotent", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
+      end
+      context 'and current value is true' do
+        it_behaves_like "doesn't change", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
+      end
+    end
+  end
+end

--- a/spec/acceptance/isfragment_spec.rb
+++ b/spec/acceptance/isfragment_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper_acceptance'
+
+describe 'firewall isfragment property' do
+  before :all do
+    iptables_flush_all_tables
+  end
+
+  shared_examples "is idempotent" do |value, line_match|
+    it "changes the value to #{value}" do
+      pp = <<-EOS
+          class { '::firewall': }
+          firewall { '597 - test':
+            ensure => present,
+            proto  => 'tcp',
+            #{value}
+          }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+
+      shell('iptables -S') do |r|
+        expect(r.stdout).to match(/#{line_match}/)
+      end
+    end
+  end
+  shared_examples "doesn't change" do |value, line_match|
+    it "doesn't change the value to #{value}" do
+      pp = <<-EOS
+          class { '::firewall': }
+          firewall { '597 - test':
+            ensure => present,
+            proto  => 'tcp',
+            #{value}
+          }
+      EOS
+
+      apply_manifest(pp, :catch_changes => true)
+
+      shell('iptables -S') do |r|
+        expect(r.stdout).to match(/#{line_match}/)
+      end
+    end
+  end
+
+  describe 'adding a rule' do
+    context 'when unset' do
+      before :all do
+        iptables_flush_all_tables
+      end
+      it_behaves_like 'is idempotent', '', /-A INPUT -p tcp -m comment --comment "597 - test"/
+    end
+    context 'when set to true' do
+      before :all do
+        iptables_flush_all_tables
+      end
+      it_behaves_like 'is idempotent', 'isfragment => true,', /-A INPUT -p tcp -f -m comment --comment "597 - test"/
+    end
+    context 'when set to false' do
+      before :all do
+        iptables_flush_all_tables
+      end
+      it_behaves_like "is idempotent", 'isfragment => false,', /-A INPUT -p tcp -m comment --comment "597 - test"/
+    end
+  end
+  describe 'editing a rule' do
+    context 'when unset or false' do
+      before :each do
+        iptables_flush_all_tables
+        shell('/sbin/iptables -A INPUT -p tcp -m comment --comment "597 - test"')
+      end
+      context 'and current value is false' do
+        it_behaves_like "doesn't change", 'isfragment => false,', /-A INPUT -p tcp -m comment --comment "597 - test"/
+      end
+      context 'and current value is true' do
+        it_behaves_like "is idempotent", 'isfragment => true,', /-A INPUT -p tcp -f -m comment --comment "597 - test"/
+      end
+    end
+    context 'when set to true' do
+      before :each do
+        iptables_flush_all_tables
+        shell('/sbin/iptables -A INPUT -p tcp -f -m comment --comment "597 - test"')
+      end
+      context 'and current value is false' do
+        it_behaves_like "is idempotent", 'isfragment => false,', /-A INPUT -p tcp -m comment --comment "597 - test"/
+      end
+      context 'and current value is true' do
+        it_behaves_like "doesn't change", 'isfragment => true,', /-A INPUT -p tcp -f -m comment --comment "597 - test"/
+      end
+    end
+  end
+end

--- a/spec/acceptance/socket_spec.rb
+++ b/spec/acceptance/socket_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper_acceptance'
+
+describe 'firewall socket property' do
+  before :all do
+    iptables_flush_all_tables
+  end
+
+  shared_examples "is idempotent" do |value, line_match|
+    it "changes the value to #{value}" do
+      pp = <<-EOS
+          class { '::firewall': }
+          firewall { '598 - test':
+            ensure => present,
+            proto  => 'tcp',
+            chain  => 'PREROUTING',
+            table  => 'raw',
+            #{value}
+          }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+
+      shell('iptables -t raw -S') do |r|
+        expect(r.stdout).to match(/#{line_match}/)
+      end
+    end
+  end
+  shared_examples "doesn't change" do |value, line_match|
+    it "doesn't change the value to #{value}" do
+      pp = <<-EOS
+          class { '::firewall': }
+          firewall { '598 - test':
+            ensure => present,
+            proto  => 'tcp',
+            chain  => 'PREROUTING',
+            table  => 'raw',
+            #{value}
+          }
+      EOS
+
+      apply_manifest(pp, :catch_changes => true)
+
+      shell('iptables -t raw -S') do |r|
+        expect(r.stdout).to match(/#{line_match}/)
+      end
+    end
+  end
+
+  describe 'adding a rule' do
+    context 'when unset' do
+      before :all do
+        iptables_flush_all_tables
+      end
+      it_behaves_like 'is idempotent', '', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
+    end
+    context 'when set to true' do
+      before :all do
+        iptables_flush_all_tables
+      end
+      it_behaves_like 'is idempotent', 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
+    end
+    context 'when set to false' do
+      before :all do
+        iptables_flush_all_tables
+      end
+      it_behaves_like "is idempotent", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
+    end
+  end
+  describe 'editing a rule' do
+    context 'when unset or false' do
+      before :each do
+        iptables_flush_all_tables
+        shell('/sbin/iptables -t raw -A PREROUTING -p tcp -m comment --comment "598 - test"')
+      end
+      context 'and current value is false' do
+        it_behaves_like "doesn't change", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
+      end
+      context 'and current value is true' do
+        it_behaves_like "is idempotent", 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
+      end
+    end
+    context 'when set to true' do
+      before :each do
+        iptables_flush_all_tables
+        shell('/sbin/iptables -t raw -A PREROUTING -p tcp -m socket -m comment --comment "598 - test"')
+      end
+      context 'and current value is false' do
+        it_behaves_like "is idempotent", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
+      end
+      context 'and current value is true' do
+        it_behaves_like "doesn't change", 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,10 +2,13 @@ require 'beaker-rspec'
 
 def iptables_flush_all_tables
   ['filter', 'nat', 'mangle', 'raw'].each do |t|
-    shell "/sbin/iptables -t #{t} -F" do |r|
-      r.stderr.should be_empty
-      r.exit_code.should be_zero
-    end
+    expect(shell("/sbin/iptables -t #{t} -F").stderr).to eq("")
+  end
+end
+
+def ip6tables_flush_all_tables
+  ['filter'].each do |t|
+    expect(shell("/sbin/ip6tables -t #{t} -F").stderr).to eq("")
   end
 end
 


### PR DESCRIPTION
The boolean properties had a few things incorrect with them.
- Any value passed was considered `true`. This was compounded further by the next issue.
- When the read property was false, it was set to 'nil'. This caused `<property> => false` to not work after the previous was fixed.
