### PR TITLE
(MODULES-443) Deprecate unset proto

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -318,8 +318,10 @@ Puppet::Type.newtype(:firewall) do
 
   newproperty(:proto) do
     desc <<-EOS
-      The specific protocol to match for this rule. By default this is
-      *tcp*.
+      The specific protocol to match for this rule.
+
+      DEPRECATION: The default is `tcp`, but will be `all` in a future
+      release of firewall. An explicit protocol is recommended.
     EOS
 
     newvalues(:tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :gre, :all)
@@ -984,6 +986,10 @@ Puppet::Type.newtype(:firewall) do
 
     if value(:action) && value(:jump)
       self.fail "Only one of the parameters 'action' and 'jump' can be set"
+    end
+
+    if ! @original_parameters[:proto]
+      warning "DEPRECATION: No protocol was specified for the rule '#{value(:name)}' -- the default will change from `tcp` to `all` in a future release of firewall"
     end
   end
 end

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -1578,4 +1578,16 @@ describe 'firewall type' do
     end
   end
 
+  describe 'deprecations' do
+    it 'raises a deprecation warning when no proto is passed' do
+      pp = <<-EOS
+        firewall { '597 - test':
+          ensure => present,
+          action => 'accept',
+        }
+      EOS
+
+      expect(apply_manifest(pp, :catch_failures => true).stderr).to match(/DEPRECATION: No protocol was specified for the rule '597 - test'/)
+    end
+  end
 end


### PR DESCRIPTION
iptables defaults to the protocol `all` for its rules, but the firewall
type defaults to `tcp`. We want to change the default, but will issue a
deprecation warning in the mean time.

closes #290
