### PR TITLE
Release 0.5.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,40 @@ Release notes for puppetlabs-firewall module.
 
 ---------------------------------------
 
+#### 0.5.0 - 2014-01-10
+
+##### Summary:
+This is a bigger release that brings in "recent" connection limiting (think
+"port knocking"), firewall chain purging on a per-chain/per-table basis, and
+support for a few other use cases. This release also fixes a major bug which
+could cause modifications to the wrong rules when unmanaged rules are present.
+
+##### New Features:
+* Add "recent" limiting via parameters `rdest`, `reap`, `recent`, `rhitcount`,
+  `rname`, `rseconds`, `rsource`, and `rttl`
+* Add negation support for source and destination
+* Add per-chain/table purging support to `firewallchain`
+* IPv4 specific
+  * Add random port forwarding support
+  * Add ipsec policy matching via `ipsec_dir` and `ipsec_policy`
+* IPv6 specific
+  * Add support for hop limiting via `hop_limit` parameter
+  * Add fragmentation matchers via `ishasmorefrags`, `islastfrag`, and `isfirstfrag`
+  * Add support for conntrack stateful firewall matching via `ctstate`
+
+##### Bugfixes:
+- Boolean fixups allowing false values
+- Better detection of unmanaged rules
+- Fix multiport rule detection
+- Fix sport/dport rule detection
+- Make INPUT, OUTPUT, and FORWARD not autorequired for firewall chain filter
+- Allow INPUT with the nat table
+- Fix `src_range` & `dst_range` order detection
+- Documentation clarifications
+- Fixes to spec tests
+
+---------------------------------------
+
 #### 0.4.2 - 2013-09-10
 
 Another attempt to fix the packaging issue.  We think we understand exactly

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-firewall'
-version '0.4.2'
+version '0.5.0'
 source 'git://github.com/puppetlabs/puppetlabs-firewall.git'
 author 'puppetlabs'
 license 'ASL 2.0'


### PR DESCRIPTION
##### Summary:

This is a bigger release that brings in "recent" connection limiting (think "port knocking"), firewall chain purging on a per-chain/per-table basis, and support for a few other use cases. This release also fixes a major bug which could cause modifications to the wrong rules when unmanaged rules are present.
##### New Features:
- Add "recent" limiting via parameters `rdest`, `reap`, `recent`, `rhitcount`, `rname`, `rseconds`, `rsource`, and `rttl`
- Add negation support for source and destination
- Add per-chain/table purging support to `firewallchain`
- IPv4 specific
  - Add random port forwarding support
  - Add ipsec policy matching via `ipsec_dir` and `ipsec_policy`
- IPv6 specific
  - Add support for hop limiting via `hop_limit` parameter
  - Add fragmentation matchers via `ishasmorefrags`, `islastfrag`, and `isfirstfrag`
  - Add support for conntrack stateful firewall matching via `ctstate`
##### Bugfixes:
- Boolean fixups allowing false values
- Better detection of unmanaged rules
- Fix multiport rule detection
- Fix sport/dport rule detection
- Make INPUT, OUTPUT, and FORWARD not autorequired for firewall chain filter
- Allow INPUT with the nat table
- Fix `src_range` & `dst_range` order detection
- Documentation clarifications
- Fixes to spec tests
