### PR TITLE
Remove acceptance/basic_spec

### DIFF
--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper_acceptance'
-
-# Here we put the more basic fundamental tests, ultra obvious stuff.
-describe "basic tests:" do
-  it 'make sure we have copied the module across' do
-    shell('ls /etc/puppet/modules/firewall/Modulefile', {:acceptable_exit_codes => 0})
-  end
-end


### PR DESCRIPTION
This removes the legacy "basic_spec" that was used as an introduction to
module testing.  It assumes the FOSS path for the module dir.  Since the
default module dir changes in PE depending on whether or not the module
is distributed with PE or not, these basic specs have been removed from
other modules.
