### PR TITLE
Fix various differences for rhel5

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -26,6 +26,14 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :ip6tables_save => 'ip6tables-save',
   })
 
+  def initialize(*args)
+    if Facter.fact('ip6tables_version').value.match /1\.3\.\d/
+      raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables'
+    else
+      super
+    end
+  end
+
   def self.iptables(*args)
     ip6tables(*args)
   end

--- a/spec/acceptance/change_source_spec.rb
+++ b/spec/acceptance/change_source_spec.rb
@@ -30,17 +30,17 @@ describe 'firewall type' do
 
     it 'adds a unmanaged rule without a comment' do
       shell('/sbin/iptables -A INPUT -t filter -s 8.0.0.3/32 -p tcp -m multiport --ports 102 -j ACCEPT')
-      expect(shell('iptables-save').stdout).to match(/-A INPUT -s 8\.0\.0\.3\/32 -p tcp -m multiport --ports 102 -j ACCEPT/)
+      expect(shell('iptables-save').stdout).to match(/-A INPUT -s 8\.0\.0\.3(\/32)? -p tcp -m multiport --ports 102 -j ACCEPT/)
     end
 
     it 'contains the changable 8.0.0.1 rule' do
       shell('iptables-save') do |r|
-        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.1\/32 -p tcp -m multiport --ports 101 -m comment --comment "101 test source changes" -j ACCEPT/)
+        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.1(\/32)? -p tcp -m multiport --ports 101 -m comment --comment "101 test source changes" -j ACCEPT/)
       end
     end
     it 'contains the static 8.0.0.2 rule' do
       shell('iptables-save') do |r|
-        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.2\/32 -p tcp -m multiport --ports 100 -m comment --comment "100 test source static" -j ACCEPT/)
+        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.2(\/32)? -p tcp -m multiport --ports 100 -m comment --comment "100 test source static" -j ACCEPT/)
       end
     end
 
@@ -65,12 +65,12 @@ describe 'firewall type' do
     end
     it 'contains the staic 8.0.0.2 rule' do
       shell('iptables-save') do |r|
-        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.2\/32 -p tcp -m multiport --ports 100 -m comment --comment "100 test source static" -j ACCEPT/)
+        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.2(\/32)? -p tcp -m multiport --ports 100 -m comment --comment "100 test source static" -j ACCEPT/)
       end
     end
     it 'contains the changing new 8.0.0.4 rule' do
       shell('iptables-save') do |r|
-        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.4\/32 -p tcp -m multiport --ports 101 -m comment --comment "101 test source changes" -j ACCEPT/)
+        expect(r.stdout).to match(/-A INPUT -s 8\.0\.0\.4(\/32)? -p tcp -m multiport --ports 101 -m comment --comment "101 test source changes" -j ACCEPT/)
       end
     end
   end

--- a/spec/acceptance/ip6_fragment_spec.rb
+++ b/spec/acceptance/ip6_fragment_spec.rb
@@ -1,93 +1,113 @@
 require 'spec_helper_acceptance'
 
-describe 'firewall ishasmorefrags/islastfrag/isfirstfrag properties' do
-  before :all do
-    ip6tables_flush_all_tables
-  end
+if default['platform'] =~ /el-5/
+  describe "firewall ip6tables doesn't work on 1.3.5 because --comment is missing" do
+    before :all do
+      ip6tables_flush_all_tables
+    end
 
-  shared_examples "is idempotent" do |values, line_match|
-    it "changes the values to #{values}" do
+    it "can't use ip6tables" do
       pp = <<-EOS
-          class { '::firewall': }
-          firewall { '599 - test':
-            ensure   => present,
-            proto    => 'tcp',
-            provider => 'ip6tables',
-            #{values}
-          }
+        class { '::firewall': }
+        firewall { '599 - test':
+          ensure   => present,
+          proto    => 'tcp',
+          provider => 'ip6tables',
+        }
       EOS
-
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
-
-      shell('ip6tables-save') do |r|
-        expect(r.stdout).to match(/#{line_match}/)
-      end
+      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/ip6tables provider is not supported/)
     end
   end
-  shared_examples "doesn't change" do |values, line_match|
-    it "doesn't change the values to #{values}" do
-      pp = <<-EOS
-          class { '::firewall': }
-          firewall { '599 - test':
-            ensure   => present,
-            proto    => 'tcp',
-            provider => 'ip6tables',
-            #{values}
-          }
-      EOS
+else
+  describe 'firewall ishasmorefrags/islastfrag/isfirstfrag properties' do
+    before :all do
+      ip6tables_flush_all_tables
+    end
 
-      apply_manifest(pp, :catch_changes => true)
+    shared_examples "is idempotent" do |values, line_match|
+      it "changes the values to #{values}" do
+        pp = <<-EOS
+            class { '::firewall': }
+            firewall { '599 - test':
+              ensure   => present,
+              proto    => 'tcp',
+              provider => 'ip6tables',
+              #{values}
+            }
+        EOS
 
-      shell('ip6tables-save') do |r|
-        expect(r.stdout).to match(/#{line_match}/)
-      end
-    end
-  end
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
 
-  describe 'adding a rule' do
-    context 'when unset' do
-      before :all do
-        ip6tables_flush_all_tables
+        shell('ip6tables-save') do |r|
+          expect(r.stdout).to match(/#{line_match}/)
+        end
       end
-      it_behaves_like 'is idempotent', '', /-A INPUT -p tcp -m comment --comment "599 - test"/
     end
-    context 'when set to true' do
-      before :all do
-        ip6tables_flush_all_tables
+    shared_examples "doesn't change" do |values, line_match|
+      it "doesn't change the values to #{values}" do
+        pp = <<-EOS
+            class { '::firewall': }
+            firewall { '599 - test':
+              ensure   => present,
+              proto    => 'tcp',
+              provider => 'ip6tables',
+              #{values}
+            }
+        EOS
+
+        apply_manifest(pp, :catch_changes => true)
+
+        shell('ip6tables-save') do |r|
+          expect(r.stdout).to match(/#{line_match}/)
+        end
       end
-      it_behaves_like "is idempotent", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
     end
-    context 'when set to false' do
-      before :all do
-        ip6tables_flush_all_tables
+
+    describe 'adding a rule' do
+      context 'when unset' do
+        before :all do
+          ip6tables_flush_all_tables
+        end
+        it_behaves_like 'is idempotent', '', /-A INPUT -p tcp -m comment --comment "599 - test"/
       end
-      it_behaves_like "is idempotent", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
-    end
-  end
-  describe 'editing a rule' do
-    context 'when unset or false' do
-      before :each do
-        ip6tables_flush_all_tables
-        shell('/sbin/ip6tables -A INPUT -p tcp -m comment --comment "599 - test"')
-      end
-      context 'and current value is false' do
-        it_behaves_like "doesn't change", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
-      end
-      context 'and current value is true' do
+      context 'when set to true' do
+        before :all do
+          ip6tables_flush_all_tables
+        end
         it_behaves_like "is idempotent", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
       end
-    end
-    context 'when set to true' do
-      before :each do
-        ip6tables_flush_all_tables
-        shell('/sbin/ip6tables -A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"')
-      end
-      context 'and current value is false' do
+      context 'when set to false' do
+        before :all do
+          ip6tables_flush_all_tables
+        end
         it_behaves_like "is idempotent", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
       end
-      context 'and current value is true' do
-        it_behaves_like "doesn't change", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
+    end
+    describe 'editing a rule' do
+      context 'when unset or false' do
+        before :each do
+          ip6tables_flush_all_tables
+          shell('/sbin/ip6tables -A INPUT -p tcp -m comment --comment "599 - test"')
+        end
+        context 'and current value is false' do
+          it_behaves_like "doesn't change", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
+        end
+        context 'and current value is true' do
+          it_behaves_like "is idempotent", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
+        end
+      end
+      context 'when set to true' do
+        before :each do
+          ip6tables_flush_all_tables
+          shell('/sbin/ip6tables -A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"')
+        end
+        context 'and current value is false' do
+          it_behaves_like "is idempotent", 'ishasmorefrags => false, islastfrag => false, isfirstfrag => false', /-A INPUT -p tcp -m comment --comment "599 - test"/
+        end
+        context 'and current value is true' do
+          it_behaves_like "doesn't change", 'ishasmorefrags => true, islastfrag => true, isfirstfrag => true', /-A INPUT -p tcp -m frag --fragid 0 --fragmore -m frag --fragid 0 --fraglast -m frag --fragid 0 --fragfirst -m comment --comment "599 - test"/
+        end
       end
     end
   end

--- a/spec/acceptance/purge_spec.rb
+++ b/spec/acceptance/purge_spec.rb
@@ -118,7 +118,7 @@ describe "purge tests:" do
 
       apply_manifest(pp, :catch_failures => true)
 
-      expect(shell('/sbin/iptables-save').stdout).to match(/-A INPUT -s 1\.2\.1\.1\/32 -p tcp\s?\n-A INPUT -s 1\.2\.1\.1\/32 -p udp/)
+      expect(shell('/sbin/iptables-save').stdout).to match(/-A INPUT -s 1\.2\.1\.1(\/32)? -p tcp\s?\n-A INPUT -s 1\.2\.1\.1(\/32)? -p udp/)
     end
   end
 end

--- a/spec/acceptance/rules_spec.rb
+++ b/spec/acceptance/rules_spec.rb
@@ -103,10 +103,10 @@ describe 'complex ruleset 1' do
         /INPUT ACCEPT/,
         /FORWARD ACCEPT/,
         /OUTPUT ACCEPT/,
-        /-A FORWARD -s 10.0.0.0\/8 -d 10.0.0.0\/8 -m comment --comment \"090 forward allow local\" -j ACCEPT/,
-        /-A FORWARD -s 10.0.0.0\/8 ! -d 10.0.0.0\/8 -p icmp -m comment --comment \"100 forward standard allow icmp\" -j ACCEPT/,
-        /-A FORWARD -s 10.0.0.0\/8 ! -d 10.0.0.0\/8 -p tcp -m multiport --ports 80,443,21,20,22,53,123,43,873,25,465 -m comment --comment \"100 forward standard allow tcp\" -m state --state NEW -j ACCEPT/,
-        /-A FORWARD -s 10.0.0.0\/8 ! -d 10.0.0.0\/8 -p udp -m multiport --ports 53,123 -m comment --comment \"100 forward standard allow udp\" -j ACCEPT/
+        /-A FORWARD -s 10.0.0.0\/(8|255\.0\.0\.0) -d 10.0.0.0\/(8|255\.0\.0\.0) -m comment --comment \"090 forward allow local\" -j ACCEPT/,
+        /-A FORWARD -s 10.0.0.0\/(8|255\.0\.0\.0) (! -d|-d !) 10.0.0.0\/(8|255\.0\.0\.0) -p icmp -m comment --comment \"100 forward standard allow icmp\" -j ACCEPT/,
+        /-A FORWARD -s 10.0.0.0\/(8|255\.0\.0\.0) (! -d|-d !) 10.0.0.0\/(8|255\.0\.0\.0) -p tcp -m multiport --ports 80,443,21,20,22,53,123,43,873,25,465 -m comment --comment \"100 forward standard allow tcp\" -m state --state NEW -j ACCEPT/,
+        /-A FORWARD -s 10.0.0.0\/(8|255\.0\.0\.0) (! -d|-d !) 10.0.0.0\/(8|255\.0\.0\.0) -p udp -m multiport --ports 53,123 -m comment --comment \"100 forward standard allow udp\" -j ACCEPT/
       ].each do |line|
         expect(r.stdout).to match(line)
       end
@@ -238,7 +238,7 @@ describe 'complex ruleset 2' do
         /-A INPUT -m comment --comment \"010 INPUT allow established and related\" -m state --state RELATED,ESTABLISHED -j ACCEPT/,
         /-A INPUT -i lo -m comment --comment \"012 accept loopback\" -j ACCEPT/,
         /-A INPUT -p icmp -m comment --comment \"013 icmp destination-unreachable\" -m icmp --icmp-type 3 -j ACCEPT/,
-        /-A INPUT -s 10.0.0.0\/8 -p icmp -m comment --comment \"013 icmp echo-request\" -m icmp --icmp-type 8 -j ACCEPT/,
+        /-A INPUT -s 10.0.0.0\/(8|255\.0\.0\.0) -p icmp -m comment --comment \"013 icmp echo-request\" -m icmp --icmp-type 8 -j ACCEPT/,
         /-A INPUT -p icmp -m comment --comment \"013 icmp time-exceeded\" -m icmp --icmp-type 11 -j ACCEPT/,
         /-A INPUT -p tcp -m multiport --dports 22 -m comment --comment \"020 ssh\" -m state --state NEW -j ACCEPT/,
         /-A INPUT -m comment --comment \"900 LOCAL_INPUT\" -j LOCAL_INPUT/,

--- a/spec/acceptance/socket_spec.rb
+++ b/spec/acceptance/socket_spec.rb
@@ -1,95 +1,98 @@
 require 'spec_helper_acceptance'
 
-describe 'firewall socket property' do
-  before :all do
-    iptables_flush_all_tables
-  end
+# RHEL5 does not support -m socket
+if default['platform'] !~ /el-5/
+  describe 'firewall socket property' do
+    before :all do
+      iptables_flush_all_tables
+    end
 
-  shared_examples "is idempotent" do |value, line_match|
-    it "changes the value to #{value}" do
-      pp = <<-EOS
-          class { '::firewall': }
-          firewall { '598 - test':
-            ensure => present,
-            proto  => 'tcp',
-            chain  => 'PREROUTING',
-            table  => 'raw',
-            #{value}
-          }
-      EOS
+    shared_examples "is idempotent" do |value, line_match|
+      it "changes the value to #{value}" do
+        pp = <<-EOS
+            class { '::firewall': }
+            firewall { '598 - test':
+              ensure => present,
+              proto  => 'tcp',
+              chain  => 'PREROUTING',
+              table  => 'raw',
+              #{value}
+            }
+        EOS
 
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
 
-      shell('iptables-save -t raw') do |r|
-        expect(r.stdout).to match(/#{line_match}/)
+        shell('iptables-save -t raw') do |r|
+          expect(r.stdout).to match(/#{line_match}/)
+        end
       end
     end
-  end
-  shared_examples "doesn't change" do |value, line_match|
-    it "doesn't change the value to #{value}" do
-      pp = <<-EOS
-          class { '::firewall': }
-          firewall { '598 - test':
-            ensure => present,
-            proto  => 'tcp',
-            chain  => 'PREROUTING',
-            table  => 'raw',
-            #{value}
-          }
-      EOS
+    shared_examples "doesn't change" do |value, line_match|
+      it "doesn't change the value to #{value}" do
+        pp = <<-EOS
+            class { '::firewall': }
+            firewall { '598 - test':
+              ensure => present,
+              proto  => 'tcp',
+              chain  => 'PREROUTING',
+              table  => 'raw',
+              #{value}
+            }
+        EOS
 
-      apply_manifest(pp, :catch_changes => true)
+        apply_manifest(pp, :catch_changes => true)
 
-      shell('iptables-save -t raw') do |r|
-        expect(r.stdout).to match(/#{line_match}/)
+        shell('iptables-save -t raw') do |r|
+          expect(r.stdout).to match(/#{line_match}/)
+        end
       end
     end
-  end
 
-  describe 'adding a rule' do
-    context 'when unset' do
-      before :all do
-        iptables_flush_all_tables
+    describe 'adding a rule' do
+      context 'when unset' do
+        before :all do
+          iptables_flush_all_tables
+        end
+        it_behaves_like 'is idempotent', '', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
       end
-      it_behaves_like 'is idempotent', '', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
-    end
-    context 'when set to true' do
-      before :all do
-        iptables_flush_all_tables
+      context 'when set to true' do
+        before :all do
+          iptables_flush_all_tables
+        end
+        it_behaves_like 'is idempotent', 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
       end
-      it_behaves_like 'is idempotent', 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
-    end
-    context 'when set to false' do
-      before :all do
-        iptables_flush_all_tables
-      end
-      it_behaves_like "is idempotent", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
-    end
-  end
-  describe 'editing a rule' do
-    context 'when unset or false' do
-      before :each do
-        iptables_flush_all_tables
-        shell('/sbin/iptables -t raw -A PREROUTING -p tcp -m comment --comment "598 - test"')
-      end
-      context 'and current value is false' do
-        it_behaves_like "doesn't change", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
-      end
-      context 'and current value is true' do
-        it_behaves_like "is idempotent", 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
-      end
-    end
-    context 'when set to true' do
-      before :each do
-        iptables_flush_all_tables
-        shell('/sbin/iptables -t raw -A PREROUTING -p tcp -m socket -m comment --comment "598 - test"')
-      end
-      context 'and current value is false' do
+      context 'when set to false' do
+        before :all do
+          iptables_flush_all_tables
+        end
         it_behaves_like "is idempotent", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
       end
-      context 'and current value is true' do
-        it_behaves_like "doesn't change", 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
+    end
+    describe 'editing a rule' do
+      context 'when unset or false' do
+        before :each do
+          iptables_flush_all_tables
+          shell('/sbin/iptables -t raw -A PREROUTING -p tcp -m comment --comment "598 - test"')
+        end
+        context 'and current value is false' do
+          it_behaves_like "doesn't change", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
+        end
+        context 'and current value is true' do
+          it_behaves_like "is idempotent", 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
+        end
+      end
+      context 'when set to true' do
+        before :each do
+          iptables_flush_all_tables
+          shell('/sbin/iptables -t raw -A PREROUTING -p tcp -m socket -m comment --comment "598 - test"')
+        end
+        context 'and current value is false' do
+          it_behaves_like "is idempotent", 'socket => false,', /-A PREROUTING -p tcp -m comment --comment "598 - test"/
+        end
+        context 'and current value is true' do
+          it_behaves_like "doesn't change", 'socket => true,', /-A PREROUTING -p tcp -m socket -m comment --comment "598 - test"/
+        end
       end
     end
   end


### PR DESCRIPTION
iptables 1.3.5 ships on rhel 5 and is really old. It doesn't support `--comment` on ip6tables, doesn't support `-m socket` or `--random`, and the format of netmasks uses subnet mask format instead of CIDR.
