### PR TITLE
Puppet-lint fix for > 80 character line

### DIFF
--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -24,7 +24,8 @@ class firewall::linux (
   }
 
   case $::operatingsystem {
-    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer': {
+    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos',
+    'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer': {
       class { "${title}::redhat":
         ensure  => $ensure,
         enable  => $enable,


### PR DESCRIPTION
Quick puppet-lint fix for > 80 character lines
