### PR TITLE
Release 1.0.1

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,10 @@ Release notes for puppetlabs-firewall module.
 
 ---------------------------------------
 
+#### 1.0.1 - 2014-02-18
+
+Bugfix: gracefully fail to manage ip6tables on iptables 1.3.x
+
 #### 1.0.0 - 2014-02-11
 
 No changes, just renumbering to 1.0.0.

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-firewall'
-version '1.0.0'
+version '1.0.1'
 source 'git://github.com/puppetlabs/puppetlabs-firewall.git'
 author 'puppetlabs'
 license 'ASL 2.0'


### PR DESCRIPTION
Bugfix: gracefully fail to manage ip6tables on iptables 1.3.x
