### PR TITLE
cache retrieved firewall rules

### DIFF
--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -206,7 +206,11 @@ Puppet::Type.newtype(:firewallchain) do
                end
 
     # gather a list of all rules present on the system
-    rules_resources = Puppet::Type.type(:firewall).instances
+    if not self.class.class_variable_defined?(:@@rule_resources)
+      self.class.send(:class_variable_set,:@@rule_resources,Puppet::Type.type(type).instances)
+    end
+    
+    rules_resources = self.class.send(:class_variable_get,:@@rule_resources).dup
 
     # Keep only rules in this chain
     rules_resources.delete_if { |res| (res[:provider] != provider or res.provider.properties[:table].to_s != table or res.provider.properties[:chain] != chain) }


### PR DESCRIPTION
I have ~6000 firewall rules on some of my hosts that are managed externally to puppet. The current implementation means that for every firewall chain resource that exists (there are at least 14 when you factor in prerouting, postrouting, nat ipv4 and ipv6, input and output, etc.) puppet must re-parse 6000 firewall rules. The patch uses a class variable to cache the rules inside of the firewallchain type class. This cut my puppet runs from 10 minutes down to just over 2 minutes.

Even with this patch, all existing firewall rules are retrieved twice: once for the firewall type's prefetching and once for the firewallchain type's purposes. Perhaps the ideal mechanism is to cache the instances within the firewall type. I don't know which approach is more "puppet-y".
