### PR TITLE
WIP Firewallchain cache fw rules

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -174,8 +174,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     @property_hash.clear
   end
 
-  def self.instances
-    debug "[instances]"
+  def self.cache_instances
+    debug "[cache_instances]"
     table = nil
     rules = []
     counter = 1
@@ -194,6 +194,14 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
       end
     end
     rules
+  end
+
+  def self.instances
+    debug "[instances]"
+    if not class_variable_defined?(:@@cache_instances)
+      class_variable_set(:@@cache_instances,cache_instances)
+    end
+    class_variable_get(:@@cache_instances)
   end
 
   def self.rule_to_hash(line, table, counter)

--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -206,11 +206,7 @@ Puppet::Type.newtype(:firewallchain) do
                end
 
     # gather a list of all rules present on the system
-    if not self.class.class_variable_defined?(:@@rule_resources)
-      self.class.send(:class_variable_set,:@@rule_resources,Puppet::Type.type(type).instances)
-    end
-    
-    rules_resources = self.class.send(:class_variable_get,:@@rule_resources).dup
+    rules_resources = Puppet::Type.type(:firewall).instances
 
     # Keep only rules in this chain
     rules_resources.delete_if { |res| (res[:provider] != provider or res.provider.properties[:table].to_s != table or res.provider.properties[:chain] != chain) }


### PR DESCRIPTION
This is a modified implementation of #333

Profiling information for a node with 5000 rules on the `filter` table at https://gist.github.com/hunner/9379414

WIP notes: I dislike that I have to copy the whole `Puppet::Type.instances` method to just add an argument. Is there any better way?
