### PR TITLE
Fix typo in SNAT error message

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -981,7 +981,7 @@ Puppet::Type.newtype(:firewall) do
       end
 
       unless value(:tosource)
-        self.fail "Parameter jump => DNAT must have tosource parameter"
+        self.fail "Parameter jump => SNAT must have tosource parameter"
       end
     end
 


### PR DESCRIPTION
SNAT: typo in error message when tosource parameter is missing.
