### PR TITLE
--reap flag is not added to iptables command

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -777,6 +777,8 @@ Puppet::Type.newtype(:firewall) do
       attribute. When used, this will cause entries older than 'seconds' to be
       purged.  Must be boolean true.
     EOS
+
+    newvalues(:true, :false)
   end
 
   newproperty(:rhitcount, :required_features => :recent_limiting) do


### PR DESCRIPTION
In lib/puppet/provider/firewall/iptables.rb we test on boolean flags when building iptables args:

```
    # If socket is true then do not add the value as -m socket is standalone
    if known_booleans.include?(res) then
      if resource[res] == :true then
        resource_value = nil
      else
        # If the property is not :true then we don't want to add the value
        # to the args list
        next
      end
    end
```

This evaluates to false on the reap flag in a definition like this:
    firewall { '001 rate limit ssh attempts':
        port   => [22],
        proto  => tcp,
        tcp_flags => "FIN,SYN,RST,ACK SYN",
        recent => 'rcheck',
        rsource => true,
        rname => 'ssh-syn4',
        rseconds => 30,
        rhitcount => 3,
        reap => true,
        jump => drop,
    }

This is because the value is not defined as a string, so the reap flag is not added to the args. This patch defines reap as a string true or false to match others like rsource.
