### PR TITLE
Fix support for Fedora Rawhide

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -26,7 +26,7 @@ class firewall::linux::redhat (
     }
   }
 
-  if $::operatingsystem == Fedora and $::operatingsystemrelease >= 15 {
+  if ($::operatingsystem == 'Fedora' and (is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 15 or $::operatingsystemrelease == "Rawhide")) {
     package { 'iptables-services':
       ensure => present,
     }


### PR DESCRIPTION
On Fedora facter $::operatingsystemrelease can be integer version of Fedora or string Rawhide.
