### PR TITLE
add ipset support

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -53,6 +53,7 @@ Puppet::Type.newtype(:firewall) do
   feature :isfirstfrag, "Match the first fragment of a fragmented ipv6 packet"
   feature :ipsec_policy, "Match IPsec policy"
   feature :ipsec_dir, "Match IPsec policy direction"
+  feature :ipset, "Match against specified ipset list"
 
   # provider specific features
   feature :iptables, "The provider provides iptables features."
@@ -897,6 +898,15 @@ Puppet::Type.newtype(:firewall) do
 	  EOS
 
 	  newvalues(:in, :out)
+  end
+
+  newproperty(:ipset, :required_features => :ipset) do
+    desc <<-EOS
+      Matches against the specified ipset list.
+      The value is the name of the blacklist, followed by a space, and then
+      'src' and/or 'dst' separated by a comma.
+      For example: 'blacklist src,dst'
+    EOS
   end
 
   newparam(:line) do


### PR DESCRIPTION
This adds support for ipset matching.

On a side note, the implementation of this was undesirable due to limitations in the firewall module. I wanted to be able to do:

```
firewall { '005 ipset blacklist':
  chain => 'INPUT',
  ipset => 'blacklist',
  ipset_match => ['src','dst'],
  action => 'drop',
}
```

but couldn't because the command line form is `--match-set blacklist src,dst`, and the firewall module does not support multi-argument parameters. So it had to be done as a single space-delimited option:

```
firewall { '005 ipset blacklist':
  chain => 'INPUT',
  ipset => 'blacklist src,dst',
  action => 'drop',
}
```
