### PR TITLE
make extension parameter ordering easier to understand

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -135,19 +135,42 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     end
   end
 
-  # This is the order of resources as they appear in iptables-save output,
-  # we need it to properly parse and apply rules, if the order of resource
-  # changes between puppet runs, the changed rules will be re-applied again.
-  # This order can be determined by going through iptables source code or just tweaking and trying manually
-  @resource_list = [
-    :table, :source, :destination, :iniface, :outiface, :proto, :isfragment,
-    :src_range, :dst_range, :tcp_flags, :gid, :uid, :sport, :dport, :port,
-    :dst_type, :src_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy,
-    :state, :ctstate, :icmp, :limit, :burst, :recent, :rseconds, :reap,
-    :rhitcount, :rttl, :rname, :rsource, :rdest, :jump, :todest, :tosource,
-    :toports, :random, :log_prefix, :log_level, :reject, :set_mark,
-    :connlimit_above, :connlimit_mask, :connmark
+  # When adding new resources, it is important that you add them to the appropriate group.
+  # The parameters of each extension must also be in the right order. You can determine this
+  # order by looking at the iptables source, or the output of `iptables-save`.
+  # If you add an extension to the wrong group, or add the parameters of that extension in
+  # the wrong order, puppet will end up reapplying the rule every run.
+  parameters = [
+    :source, :destination, :iniface, :outiface, :proto, :isfragment,
   ]
+  match_extensions = [
+    :src_range, :dst_range,
+    :tcp_flags,
+    :gid, :uid,
+    :sport, :dport, :port,
+    :dst_type, :src_type,
+    :socket,
+    :pkttype,
+    :name,
+    :ipsec_dir, :ipsec_policy,
+    :state, :ctstate,
+    :icmp,
+    :limit, :burst,
+    :recent, :rseconds, :reap, :rhitcount, :rttl, :rname, :rsource, :rdest,
+  ]
+  target_extensions = [
+    :todest,
+    :tosource,
+    :toports,
+    :random,
+    :log_prefix, :log_level,
+    :reject,
+    :set_mark,
+    :connlimit_above,
+    :connlimit_mask,
+    :connmark,
+  ]
+  @resource_list = [:table] + parameters + match_extensions + [:jump] + target_extensions
 
   def insert
     debug 'Inserting rule %s' % resource[:name]


### PR DESCRIPTION
This commit makes it easier to add extensions to the firewall module.

Currently when adding a new extension, you have to deal with this big ugly warning telling you that resources must be added in a specific order or you'll end up with puppet constantly re-applying the firewall rules. This is not true. The order of the various extensions does not matter, only the order of the options for each extension matters.
For example:

```
$ iptables -A OUTPUT -p tcp -m state --state new -m limit --limit 10 --limit-burst 100 -j ACCEPT
$ iptables-save | grep limit-burst
-A OUTPUT -p tcp -m state --state NEW -m limit --limit 10/sec --limit-burst 100 -j ACCEPT
```

```
$ iptables -A OUTPUT -p tcp -m limit --limit 10 --limit-burst 100 -m state --state new -j ACCEPT
$ iptables-save | grep limit-burst
-A OUTPUT -p tcp -m limit --limit 10/sec --limit-burst 100 -m state --state NEW -j ACCEPT
```

Notice that the output of `iptables-save` was given back in the exact same order as was used to create the rules.
But note that the order of the options for the `limit` extension does matter:

```
$ iptables -A OUTPUT -p tcp -m limit --limit-burst 100 --limit 10 -m state --state new -j ACCEPT
$ iptables-save | grep limit-burst
-A OUTPUT -p tcp -m limit --limit 10/sec --limit-burst 100 -m state --state NEW -j ACCEPT
```

&nbsp;
The order of the target extensions does not matter either. But this is because you can only have a single target. You can't have both `-j DNAT --to-destination 1.2.3.4` and `-j LOG --log-prefix foo --log-level 7`.
But again, the order of the options to each target extension does matter.

Additionally we separate the built-in options into their own `parameters` array. The order of these does matter, but they're constant and never change.

So now when adding a new extension, you just add a line to either the `match_extensions` array, or the `target_extensions` array.

---

This is all defined by the iptables man page:

```
iptables [-t table] -I chain [rulenum] rule-specification

rule-specification = [matches...] [target]
match = -m matchname [per-match-options]
target = -j targetname [per-target-options]
```

---

But ultimately this is really just a band aid. I think the firewall module really needs proper handling of extensions. We should be able to define "here's an extension, here's the options the extension supports, and here's what each option means". Then you don't have to worry about order at all, you immediately know that the `--state` option belongs to the `state` match extension, and that `--to-destination` belongs to the `DNAT` target extension.
