### PR TITLE
Fix support for Fedora Rawhide

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -26,7 +26,7 @@ class firewall::linux::redhat (
     }
   }
 
-  if $::operatingsystem == Fedora and $::operatingsystemrelease >= 15 {
+  if ($::operatingsystem == 'Fedora' and (( $::operatingsystemrelease =~ /^\d+/ and $::operatingsystemrelease >= 15 ) or $::operatingsystemrelease == "Rawhide")) {
     package { 'iptables-services':
       ensure => present,
     }

--- a/spec/unit/classes/firewall_linux_spec.rb
+++ b/spec/unit/classes/firewall_linux_spec.rb
@@ -7,7 +7,7 @@ describe 'firewall::linux', :type => :class do
   context 'RedHat like' do
     %w{RedHat CentOS Fedora}.each do |os|
       context "operatingsystem => #{os}" do
-        releases = (os == 'Fedora' ? [14,15] : [6,7])
+        releases = (os == 'Fedora' ? [14,15,'Rawhide'] : [6,7])
         releases.each do |osrel|
           context "operatingsystemrelease => #{osrel}" do
             let(:facts) { facts_default.merge({ :operatingsystem => os,


### PR DESCRIPTION
Fact operatingsystemrelease sadly can be integer or string on Fedora, we need to pull in stdlib to get is_integer function for this.
