### PR TITLE
Ensure latest iptables on RedHat osfamily

### DIFF
--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -19,8 +19,14 @@ class firewall::linux (
     stopped => false,
   }
 
+  if $::osfamily == 'RedHat' {
+    $package_ensure = 'latest'
+  } else {
+    $package_ensure = 'present'
+  }
+
   package { 'iptables':
-    ensure => present,
+    ensure => $package_ensure,
   }
 
   case $::operatingsystem {


### PR DESCRIPTION
For Fedora15+ and RHEL-7+ we need to ensure that latest iptables package
is installed so that iptables-services package installation won't fail.
