### PR TITLE
ensure that /etc/sysconfig/iptables exists

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -38,11 +38,11 @@ class firewall::linux::redhat (
     hasstatus => true,
     require   => File['/etc/sysconfig/iptables'],
   }
-  
+
   file { '/etc/sysconfig/iptables':
     ensure => present,
     owner  => root,
     group   => root,
-    mode   => "0600",
+    mode   => 0600,
   }
 }


### PR DESCRIPTION
The iptables service will not start if /etc/sysconfig/iptables is
missing.  Attempting to start the service without this file will result
in:

ERROR : Error appeared during Puppet run: 172.16.0.14_prescript.pp
Error: Could not start Service[iptables]: Execution of '/sbin/service
iptables start' returned 6:

This patch ensures the file exists before starting the iptables service.
