### PR TITLE
(doc) Fix small typos in the README (MODULES-11)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -92,7 +92,7 @@ The `pre` class should be located in `my_fw/manifests/pre.pp` and should contain
       }->
       firewall { '002 accept related established rules':
         proto   => 'all',
-        state => ['RELATED', 'ESTABLISHED'],
+        ctstate => ['RELATED', 'ESTABLISHED'],
         action  => 'accept',
       }
     }
@@ -163,7 +163,7 @@ With the latest version, we now have in-built persistence, so this is no longer 
     class { ['my_fw::pre', 'my_fw::post']: }
     class { 'firewall': }
 
-Consult the the documentation below for more details around the classes `my_fw::pre` and `my_fw::post`.
+Consult the documentation below for more details around the classes `my_fw::pre` and `my_fw::post`.
 
 ##Usage
 


### PR DESCRIPTION
For https://tickets.puppetlabs.com/browse/MODULES-11

Double "the" fixed and undo a typo fix that reverted this commit:
https://github.com/puppetlabs/puppetlabs-firewall/commit/13457a4ade45f4a46d64ceb4da9d2b9582c39fcd
