### PR TITLE
Fixed bug which arbitrarily limited iniface and outiface parameters

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -973,20 +973,6 @@ Puppet::Type.newtype(:firewall) do
 
     # Now we analyse the individual properties to make sure they apply to
     # the correct combinations.
-    if value(:iniface)
-      unless value(:chain).to_s =~ /INPUT|FORWARD|PREROUTING/
-        self.fail "Parameter iniface only applies to chains " \
-          "INPUT,FORWARD,PREROUTING"
-      end
-    end
-
-    if value(:outiface)
-      unless value(:chain).to_s =~ /OUTPUT|FORWARD|POSTROUTING/
-        self.fail "Parameter outiface only applies to chains " \
-          "OUTPUT,FORWARD,POSTROUTING"
-      end
-    end
-
     if value(:uid)
       unless value(:chain).to_s =~ /OUTPUT|POSTROUTING/
         self.fail "Parameter uid only applies to chains " \


### PR DESCRIPTION
Setting ingoing and outgoing interfaces are allowed in all chains, even own defined chains are allowed to have rules which specify in- and outgoing interfaces.
