### PR TITLE
Remove firewalld package

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -20,15 +20,23 @@ class firewall::linux::redhat (
   # RHEL 7 and later and Fedora 15 and later require the iptables-services
   # package, which provides the /usr/libexec/iptables/iptables.init used by
   # lib/puppet/util/firewall.rb.
+  # This firewall also conflicts with firewalld, which must be removed
+  # if present.
   if $::operatingsystem == RedHat and $::operatingsystemrelease >= 7 {
     package { 'iptables-services':
       ensure => present,
+    }
+    package { 'firewalld':
+      ensure => absent,
     }
   }
 
   if ($::operatingsystem == 'Fedora' and (( $::operatingsystemrelease =~ /^\d+/ and $::operatingsystemrelease >= 15 ) or $::operatingsystemrelease == "Rawhide")) {
     package { 'iptables-services':
       ensure => present,
+    }
+    package { 'firewalld':
+      ensure => absent,
     }
   }
 


### PR DESCRIPTION
If present, firewalld must be removed on RHEL 7 and Fedora systems, because it and the puppetlabs firewall will clobber each other. Unfortunately firewalld is installed by default even on minimal installations. So we must take care to ensure that it is removed.

I release this change to the public domain.
