### PR TITLE
Add testing for unsupported platforms

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -27,6 +27,8 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :ip6tables_save => 'ip6tables-save',
   })
 
+  confine :kernel => :linux
+
   def initialize(*args)
     if Facter.fact('ip6tables_version').value.match /1\.3\.\d/
       raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables'

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   })
 
   defaultfor :kernel => :linux
+  confine :kernel => :linux
 
   iptables_version = Facter.fact('iptables_version').value
   if (iptables_version and Puppet::Util::Package.versioncmp(iptables_version, '1.4.1') < 0)

--- a/lib/puppet/provider/firewallchain/iptables_chain.rb
+++ b/lib/puppet/provider/firewallchain/iptables_chain.rb
@@ -16,6 +16,7 @@ Puppet::Type.type(:firewallchain).provide :iptables_chain do
   })
 
   defaultfor :kernel => :linux
+  confine :kernel => :linux
 
   # chain name is greedy so we anchor from the end.
   # [\d+:\d+] doesn't exist on ebtables

--- a/spec/unit/classes/firewall_spec.rb
+++ b/spec/unit/classes/firewall_spec.rb
@@ -11,6 +11,16 @@ describe 'firewall', :type => :class do
     it { expect { should contain_class('firewall::linux') }.to raise_error(Puppet::Error) }
   end
 
+  context 'kernel => SunOS' do
+    let(:facts) {{ :kernel => 'SunOS' }}
+    it { expect { should contain_class('firewall::linux') }.to raise_error(Puppet::Error) }
+  end
+
+  context 'kernel => Darwin' do
+    let(:facts) {{ :kernel => 'Darwin' }}
+    it { expect { should contain_class('firewall::linux') }.to raise_error(Puppet::Error) }
+  end
+
   context 'ensure => stopped' do
     let(:facts) {{ :kernel => 'Linux' }}
     let(:params) {{ :ensure => 'stopped' }}

--- a/spec/unit/puppet/provider/iptables_chain_spec.rb
+++ b/spec/unit/puppet/provider/iptables_chain_spec.rb
@@ -21,6 +21,10 @@ describe 'iptables chain provider detection' do
   before :each do
     # Reset the default provider
     Puppet::Type.type(:firewallchain).defaultprovider = nil
+
+    # Stub confine facts
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+    allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Debian')
   end
 
   it "should default to iptables provider if /sbin/(eb|ip|ip6)tables[-save] exists" do
@@ -42,7 +46,7 @@ describe 'iptables chain provider detection' do
 
     # Every other command should return false so we don't pick up any
     # other providers
-    allow(exists).to receive(:which).with() { |value|
+    allow(exists).to receive(:which) { |value|
       value !~ /(eb|ip|ip6)tables(-save)?$/
     }.and_return false
 

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -21,6 +21,10 @@ describe 'iptables provider detection' do
   before :each do
     # Reset the default provider
     Puppet::Type.type(:firewall).defaultprovider = nil
+
+    # Stub confine facts
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+    allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Debian')
   end
 
   it "should default to iptables provider if /sbin/iptables[-save] exists" do
@@ -32,7 +36,7 @@ describe 'iptables provider detection' do
 
     # Every other command should return false so we don't pick up any
     # other providers
-    allow(exists).to receive(:which).with() { |value|
+    allow(exists).to receive(:which) { |value|
       ! ["iptables","iptables-save"].include?(value)
     }.and_return false
 
@@ -224,7 +228,7 @@ describe 'iptables provider' do
           it "the parameter '#{param_name.to_s}' should match #{param_value.inspect}" do
             # booleans get cludged to string "true"
             if param_value == true then
-              expect(resource[param_name]).to be_true
+              expect(resource[param_name]).to be_truthy
             else
               expect(resource[param_name]).to eq(data[:params][param_name])
             end

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -647,4 +647,25 @@ describe firewall do
       end
     end
   end
+  it 'is suitable' do
+    expect(@resource.suitable?).to be_truthy
+  end
+end
+
+describe 'firewall on unsupported platforms' do
+  it 'is not suitable' do
+    # Stub iptables version
+    allow(Facter.fact(:iptables_version)).to receive(:value).and_return(nil)
+    allow(Facter.fact(:ip6tables_version)).to receive(:value).and_return(nil)
+
+    # Stub confine facts
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('Darwin')
+    allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Darwin')
+    resource = firewall.new(:name => "000 test foo", :ensure => :present)
+
+    # If our provider list is nil, then the Puppet::Transaction#evaluate will
+    # say 'Error: Could not find a suitable provider for firewall' but there
+    # isn't a unit testable way to get this.
+    expect(resource.suitable?).to be_falsey
+  end
 end

--- a/spec/unit/puppet/type/firewallchain_spec.rb
+++ b/spec/unit/puppet/type/firewallchain_spec.rb
@@ -182,4 +182,25 @@ EOS
       expect(resource.generate.size).to eq(0)
     end
   end
+  it 'is suitable' do
+    expect(resource.suitable?).to be_truthy
+  end
+end
+
+describe 'firewall on unsupported platforms' do
+  it 'is not suitable' do
+    # Stub iptables version
+    allow(Facter.fact(:iptables_version)).to receive(:value).and_return(nil)
+    allow(Facter.fact(:ip6tables_version)).to receive(:value).and_return(nil)
+
+    # Stub confine facts
+    allow(Facter.fact(:kernel)).to receive(:value).and_return('Darwin')
+    allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Darwin')
+    resource = firewallchain.new(:name => "INPUT:filter:IPv4", :ensure => :present)
+
+    # If our provider list is nil, then the Puppet::Transaction#evaluate will
+    # say 'Error: Could not find a suitable provider for firewall' but there
+    # isn't a unit testable way to get this.
+    expect(resource.suitable?).to be_falsey
+  end
 end


### PR DESCRIPTION
Since this only works on linux, we confine to linux. And test it even.
