### PR TITLE
Apply firewall resources alphabetically

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -943,6 +943,10 @@ Puppet::Type.newtype(:firewall) do
     end
   end
 
+  autorequire(:firewall) do
+    catalog.resources.select { |r| (r.class.to_s == "Puppet::Type::Firewall") and (r.name <=> name) == -1  }.sort.last
+  end
+
   validate do
     debug("[validate]")
 


### PR DESCRIPTION
This has already been merged by c30cfb9219, then revert by 412620acc9.
Why has this been reverted ? I really thing this is a huge improvement for ease of use of this module.
