### PR TITLE
Add missing set_mark in the ip6tables provider

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -47,6 +47,13 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
 
   @protocol = "IPv6"
 
+  ip6tables_version = Facter.fact('ip6tables_version').value
+  if (ip6tables_version and Puppet::Util::Package.versioncmp(ip6tables_version, '1.4.1') < 0)
+    mark_flag = '--set-mark'
+  else
+    mark_flag = '--set-xmark'
+  end
+
   @resource_map = {
     :burst => "--limit-burst",
     :connlimit_above => "-m connlimit --connlimit-above",
@@ -76,6 +83,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :rseconds => "--seconds",
     :rsource => "--rsource",
     :rttl => "--rttl",
+    :set_mark => mark_flag,
     :source => "-s",
     :state => "-m state --state",
     :sport => "-m multiport --sports",
@@ -128,11 +136,12 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   # (Note: on my CentOS 6.4 ip6tables-save returns -m frag on the place
   # I put it when calling the command. So compability with manual changes
   # not provided with current parser [georg.koester])
-  @resource_list = [:table, :source, :destination, :iniface, :outiface,
-    :proto, :ishasmorefrags, :islastfrag, :isfirstfrag, :gid, :uid, :sport, :dport,
+  @resource_list = [
+    :table, :source, :destination, :iniface, :outiface, :proto,
+    :ishasmorefrags, :islastfrag, :isfirstfrag, :gid, :uid, :sport, :dport,
     :port, :pkttype, :name, :state, :ctstate, :icmp, :hop_limit, :limit, :burst,
     :recent, :rseconds, :reap, :rhitcount, :rttl, :rname, :rsource, :rdest,
     :jump, :todest, :tosource, :toports, :log_level, :log_prefix, :reject,
-    :connlimit_above, :connlimit_mask, :connmark]
+    :set_mark, :connlimit_above, :connlimit_mask, :connmark]
 
 end


### PR DESCRIPTION
I was trying to port some of my existing ip6tables rules from custom templates to the firewall module, and I was getting this error for some IPVS related mark rules : 
```
Error: Execution of '/sbin/ip6tables -I PREROUTING 1 -t mangle -d 2001:ffff:4020:1010::1/128 -p tcp -m multiport --dports 443 -m comment --comment 040 ip2 https fwmark 4 -j MARK' returned 2: ip6tables v1.4.7: MARK: One of the --set-xmark, --{and,or,xor,set}-mark options is required
Try `ip6tables -h' or 'ip6tables --help' for more information.
```
I had a look at the provider, and the set_mark parameter seemed to be missing, so I just copied over the few relevant lined from the main IPv4 provider and it now works.

This is one of the rules inside my manifest : 
```puppet
firewall { '040 ip2 https fwmark 4':
  destination => '2001:ffff:4020:1010::1',
  proto       => 'tcp',
  dport       => '443',
  table       => 'mangle',
  chain       => 'PREROUTING',
  jump        => 'MARK',
  set_mark    => '4',
  provider    => 'ip6tables',
}
```