### PR TITLE
Add cbt protocol, to be able to mitigate some DDoS attacks

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -323,7 +323,7 @@ Puppet::Type.newtype(:firewall) do
       *tcp*.
     EOS
 
-    newvalues(:tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :gre, :all)
+    newvalues(:tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :gre, :cbt, :all)
     defaultto "tcp"
   end
 


### PR DESCRIPTION
I needed to drop all cbt protocol packets on some servers, but the module didn't support that. This trivial change makes it now possible to do.
