### PR TITLE
Extend support for all RHEL clones.

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -20,7 +20,7 @@ class firewall::linux::redhat (
   # RHEL 7 and later and Fedora 15 and later require the iptables-services
   # package, which provides the /usr/libexec/iptables/iptables.init used by
   # lib/puppet/util/firewall.rb.
-  if $::operatingsystem == RedHat and $::operatingsystemrelease >= 7 {
+  if $::operatingsystem != 'Fedora' and $::operatingsystemmajrelease >= 7 {
     package { 'iptables-services':
       ensure => present,
     }

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'firewall::linux::redhat', :type => :class do
+  let(:facts) {{ :operatingsystemmajrelease => 7 }}
   it { should contain_service('iptables').with(
     :ensure => 'running',
     :enable => 'true'

--- a/spec/unit/classes/firewall_linux_spec.rb
+++ b/spec/unit/classes/firewall_linux_spec.rb
@@ -9,9 +9,9 @@ describe 'firewall::linux', :type => :class do
       context "operatingsystem => #{os}" do
         releases = (os == 'Fedora' ? [14,15,'Rawhide'] : [6,7])
         releases.each do |osrel|
-          context "operatingsystemrelease => #{osrel}" do
+          context "operatingsystemmajrelease => #{osrel}" do
             let(:facts) { facts_default.merge({ :operatingsystem => os,
-                                                :operatingsystemrelease => osrel}) }
+                                                :operatingsystemmajrelease => osrel}) }
             it { should contain_class('firewall::linux::redhat').with_require('Package[iptables]') }
           end
         end


### PR DESCRIPTION
There isn't much fedora clones than there is of RHEL, it's beeter
to just check if we aren't Fedora than listing all RHEL clones.
Also operatingsystemmajrelease is required as CentOS changed versioning.
