### PR TITLE
Improve support for EL7 and other related fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ group :development, :test do
   gem 'puppet-lint',             :require => false
   gem 'beaker',                  :require => false
   gem 'beaker-rspec',            :require => false
-  gem 'pry',                     :require => false
+  gem 'vagrant-wrapper',         :require => false
+  gem 'pry', '~> 0.9.0',         :require => false
   gem 'simplecov',               :require => false
 end
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -22,8 +22,8 @@ Puppet::Type.newtype(:firewall) do
     `chain` or `jump` parameters, the firewall resource will autorequire
     those firewallchain resources.
 
-    If Puppet is managing the iptables or iptables-persistent packages, and
-    the provider is iptables or ip6tables, the firewall resource will
+    If Puppet is managing the iptables, iptables-persistent, or iptables-services packages,
+    and the provider is iptables or ip6tables, the firewall resource will
     autorequire those packages to ensure that any required binaries are
     installed.
   EOS
@@ -937,7 +937,7 @@ Puppet::Type.newtype(:firewall) do
   autorequire(:package) do
     case value(:provider)
     when :iptables, :ip6tables
-      %w{iptables iptables-persistent}
+      %w{iptables iptables-persistent iptables-services}
     else
       []
     end

--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -18,8 +18,8 @@ Puppet::Type.newtype(:firewallchain) do
     allow it.
 
     **Autorequires:**
-    If Puppet is managing the iptables or iptables-persistent packages, and
-    the provider is iptables_chain, the firewall resource will autorequire
+    If Puppet is managing the iptables, iptables-persistent, or iptables-services packages,
+    and the provider is iptables_chain, the firewall resource will autorequire
     those packages to ensure that any required binaries are installed.
   EOS
 
@@ -151,7 +151,7 @@ Puppet::Type.newtype(:firewallchain) do
   autorequire(:package) do
     case value(:provider)
     when :iptables_chain
-      %w{iptables iptables-persistent}
+      %w{iptables iptables-persistent iptables-services}
     else
       []
     end

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -20,15 +20,15 @@ class firewall::linux::redhat (
   # RHEL 7 and later and Fedora 15 and later require the iptables-services
   # package, which provides the /usr/libexec/iptables/iptables.init used by
   # lib/puppet/util/firewall.rb.
-  if $::operatingsystem == RedHat and $::operatingsystemrelease >= 7 {
-    package { 'iptables-services':
-      ensure => present,
+  if versioncmp($::operatingsystemrelease, '7.0') >= 0 {
+    package { 'firewalld':
+      ensure  => absent,
+      before  => Package['iptables-services'],
     }
-  }
 
-  if ($::operatingsystem == 'Fedora' and (( $::operatingsystemrelease =~ /^\d+/ and $::operatingsystemrelease >= 15 ) or $::operatingsystemrelease == "Rawhide")) {
     package { 'iptables-services':
-      ensure => present,
+      ensure  => present,
+      before  => Service['iptables'],
     }
   }
 
@@ -36,5 +36,13 @@ class firewall::linux::redhat (
     ensure    => $ensure,
     enable    => $enable,
     hasstatus => true,
+    require   => File['/etc/sysconfig/iptables'],
+  }
+
+  file { '/etc/sysconfig/iptables':
+    ensure  => present,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0600',
   }
 }

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'firewall::linux::redhat', :type => :class do
+  let(:facts) {{ :operatingsystemrelease => '6.5' }}
+
   it { should contain_service('iptables').with(
     :ensure => 'running',
     :enable => 'true'
@@ -17,6 +19,19 @@ describe 'firewall::linux::redhat', :type => :class do
     let(:params) {{ :enable => 'false' }}
     it { should contain_service('iptables').with(
       :enable => 'false'
+    )}
+  end
+
+  context 'operatingsystemrelease => 7.0.1406' do
+    let(:facts) {{ :operatingsystemrelease => '7.0.1406' }}
+    it { should contain_package('firewalld').with(
+      :ensure => 'absent',
+      :before => 'Package[iptables-services]'
+    )}
+
+    it { should contain_package('iptables-services').with(
+      :ensure => 'present',
+      :before => 'Service[iptables]'
     )}
   end
 end

--- a/spec/unit/classes/firewall_linux_spec.rb
+++ b/spec/unit/classes/firewall_linux_spec.rb
@@ -7,7 +7,7 @@ describe 'firewall::linux', :type => :class do
   context 'RedHat like' do
     %w{RedHat CentOS Fedora}.each do |os|
       context "operatingsystem => #{os}" do
-        releases = (os == 'Fedora' ? [14,15,'Rawhide'] : [6,7])
+        releases = (os == 'Fedora' ? ['14','15','Rawhide'] : ['6','7'])
         releases.each do |osrel|
           context "operatingsystemrelease => #{osrel}" do
             let(:facts) { facts_default.merge({ :operatingsystem => os,

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -628,12 +628,13 @@ describe firewall do
         rel.target.ref.should == @resource.ref
       end
 
-      it "provider #{provider} should autorequire packages iptables and iptables-persistent" do
+      it "provider #{provider} should autorequire packages iptables, iptables-persistent, and iptables-services" do
         @resource[:provider] = provider
         @resource[:provider].should == provider
         packages = [
           Puppet::Type.type(:package).new(:name => 'iptables'),
-          Puppet::Type.type(:package).new(:name => 'iptables-persistent')
+          Puppet::Type.type(:package).new(:name => 'iptables-persistent'),
+          Puppet::Type.type(:package).new(:name => 'iptables-services')
         ]
         catalog = Puppet::Resource::Catalog.new
         catalog.add_resource @resource

--- a/spec/unit/puppet/type/firewallchain_spec.rb
+++ b/spec/unit/puppet/type/firewallchain_spec.rb
@@ -121,11 +121,12 @@ describe firewallchain do
       rel.target.ref.should == resource.ref
     end
 
-    it "provider iptables_chain should autorequire packages iptables and iptables-persistent" do
+    it "provider iptables_chain should autorequire packages iptables, iptables-persistent, and iptables-services" do
       resource[:provider].should == :iptables_chain
       packages = [
         Puppet::Type.type(:package).new(:name => 'iptables'),
-        Puppet::Type.type(:package).new(:name => 'iptables-persistent')
+        Puppet::Type.type(:package).new(:name => 'iptables-persistent'),
+        Puppet::Type.type(:package).new(:name => 'iptables-services')
       ]
       catalog = Puppet::Resource::Catalog.new
       catalog.add_resource resource


### PR DESCRIPTION
- Support RHEL7 by removing firewalld before installing iptables-services
- Autorequire Package[iptables-services] for Firewall and Firewallchain types
- Ensure /etc/sysconfig/iptables exists before starting Service[iptables]

This is a combination of other pull requests
- #375
- #367
- #365

The changes in #391 would likely be a good addition to this.

I'm using this code in production for CentOS 6.5 and CentOS 7.0.1406.
