### PR TITLE
Improve support for EL7 and other related fixes

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -22,8 +22,8 @@ Puppet::Type.newtype(:firewall) do
     `chain` or `jump` parameters, the firewall resource will autorequire
     those firewallchain resources.
 
-    If Puppet is managing the iptables or iptables-persistent packages, and
-    the provider is iptables or ip6tables, the firewall resource will
+    If Puppet is managing the iptables, iptables-persistent, or iptables-services packages,
+    and the provider is iptables or ip6tables, the firewall resource will
     autorequire those packages to ensure that any required binaries are
     installed.
   EOS
@@ -937,7 +937,7 @@ Puppet::Type.newtype(:firewall) do
   autorequire(:package) do
     case value(:provider)
     when :iptables, :ip6tables
-      %w{iptables iptables-persistent}
+      %w{iptables iptables-persistent iptables-services}
     else
       []
     end

--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -18,8 +18,8 @@ Puppet::Type.newtype(:firewallchain) do
     allow it.
 
     **Autorequires:**
-    If Puppet is managing the iptables or iptables-persistent packages, and
-    the provider is iptables_chain, the firewall resource will autorequire
+    If Puppet is managing the iptables, iptables-persistent, or iptables-services packages,
+    and the provider is iptables_chain, the firewall resource will autorequire
     those packages to ensure that any required binaries are installed.
   EOS
 
@@ -151,7 +151,7 @@ Puppet::Type.newtype(:firewallchain) do
   autorequire(:package) do
     case value(:provider)
     when :iptables_chain
-      %w{iptables iptables-persistent}
+      %w{iptables iptables-persistent iptables-services}
     else
       []
     end

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -1,22 +1,60 @@
 require 'spec_helper'
 
 describe 'firewall::linux::redhat', :type => :class do
-  it { should contain_service('iptables').with(
-    :ensure => 'running',
-    :enable => 'true'
-  )}
+  %w{RedHat CentOS Fedora}.each do |os|
+    oldreleases = (os == 'Fedora' ? ['14'] : ['6.5'])
+    newreleases = (os == 'Fedora' ? ['15','Rawhide'] : ['7.0.1406'])
 
-  context 'ensure => stopped' do
-    let(:params) {{ :ensure => 'stopped' }}
-    it { should contain_service('iptables').with(
-      :ensure => 'stopped'
-    )}
-  end
+    oldreleases.each do |osrel|
+      context "os #{os} and osrel #{osrel}" do
+        let(:facts) {{
+          :operatingsystem        => os,
+          :operatingsystemrelease => osrel
+        }}
 
-  context 'enable => false' do
-    let(:params) {{ :enable => 'false' }}
-    it { should contain_service('iptables').with(
-      :enable => 'false'
-    )}
+        it { should_not contain_package('firewalld') }
+        it { should_not contain_package('iptables-services') }
+      end
+    end
+
+    newreleases.each do |osrel|
+      context "os #{os} and osrel #{osrel}" do
+        let(:facts) {{
+          :operatingsystem        => os,
+          :operatingsystemrelease => osrel
+        }}
+
+        it { should contain_package('firewalld').with(
+          :ensure => 'absent',
+          :before => 'Package[iptables-services]'
+        )}
+
+        it { should contain_package('iptables-services').with(
+          :ensure => 'present',
+          :before => 'Service[iptables]'
+        )}
+      end
+    end
+
+    describe 'ensure' do
+      context 'default' do
+        it { should contain_service('iptables').with(
+          :ensure => 'running',
+          :enable => 'true'
+        )}
+      end
+      context 'ensure => stopped' do
+        let(:params) {{ :ensure => 'stopped' }}
+        it { should contain_service('iptables').with(
+          :ensure => 'stopped'
+        )}
+      end
+      context 'enable => false' do
+        let(:params) {{ :enable => 'false' }}
+        it { should contain_service('iptables').with(
+          :enable => 'false'
+        )}
+      end
+    end
   end
 end

--- a/spec/unit/classes/firewall_linux_spec.rb
+++ b/spec/unit/classes/firewall_linux_spec.rb
@@ -7,7 +7,7 @@ describe 'firewall::linux', :type => :class do
   context 'RedHat like' do
     %w{RedHat CentOS Fedora}.each do |os|
       context "operatingsystem => #{os}" do
-        releases = (os == 'Fedora' ? [14,15,'Rawhide'] : [6,7])
+        releases = (os == 'Fedora' ? ['14','15','Rawhide'] : ['6','7'])
         releases.each do |osrel|
           context "operatingsystemrelease => #{osrel}" do
             let(:facts) { facts_default.merge({ :operatingsystem => os,

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -628,12 +628,13 @@ describe firewall do
         rel.target.ref.should == @resource.ref
       end
 
-      it "provider #{provider} should autorequire packages iptables and iptables-persistent" do
+      it "provider #{provider} should autorequire packages iptables, iptables-persistent, and iptables-services" do
         @resource[:provider] = provider
         @resource[:provider].should == provider
         packages = [
           Puppet::Type.type(:package).new(:name => 'iptables'),
-          Puppet::Type.type(:package).new(:name => 'iptables-persistent')
+          Puppet::Type.type(:package).new(:name => 'iptables-persistent'),
+          Puppet::Type.type(:package).new(:name => 'iptables-services')
         ]
         catalog = Puppet::Resource::Catalog.new
         catalog.add_resource @resource

--- a/spec/unit/puppet/type/firewallchain_spec.rb
+++ b/spec/unit/puppet/type/firewallchain_spec.rb
@@ -121,11 +121,12 @@ describe firewallchain do
       rel.target.ref.should == resource.ref
     end
 
-    it "provider iptables_chain should autorequire packages iptables and iptables-persistent" do
+    it "provider iptables_chain should autorequire packages iptables, iptables-persistent, and iptables-services" do
       resource[:provider].should == :iptables_chain
       packages = [
         Puppet::Type.type(:package).new(:name => 'iptables'),
-        Puppet::Type.type(:package).new(:name => 'iptables-persistent')
+        Puppet::Type.type(:package).new(:name => 'iptables-persistent'),
+        Puppet::Type.type(:package).new(:name => 'iptables-services')
       ]
       catalog = Puppet::Resource::Catalog.new
       catalog.add_resource resource


### PR DESCRIPTION
- Support RHEL7 by removing firewalld before installing iptables-services
- Autorequire Package[iptables-services] for Firewall and Firewallchain types
- Ensure /etc/sysconfig/iptables exists before starting Service[iptables]

Closes #392 #391 #375 #367 #365
