### PR TITLE
(MODULES-450) Enable rule inversion

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -198,6 +198,28 @@ class profile::apache {
 }
 ```
 
+###Rule inversion
+Firewall rules may be inverted by prefixing the value of a parameter by "! ". If the value is an array, then every item in the array must be prefixed as iptables does not understand inverting a single value.
+
+Parameters that understand inversion are: connmark, ctstate, destination, dport, dst\_range, dst\_type, port, proto, source, sport, src\_range, src\_type, and state.
+
+Examples:
+
+```puppet
+firewall { '001 disallow esp protocol':
+  action => 'accept',
+  proto  => '! esp',
+}
+firewall { '002 drop NEW external website packets with FIN/RST/ACK set and SYN unset':
+  chain     => 'INPUT',
+  state     => 'NEW',
+  action    => 'drop',
+  proto     => 'tcp',
+  sport     => ['! http', '! 443'],
+  source    => '! 10.0.0.0/8',
+  tcp_flags => '! FIN,SYN,RST,ACK SYN',
+}
+```
 
 ###Additional Uses for the Firewall Module
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -53,6 +53,7 @@ Puppet::Type.newtype(:firewall) do
   feature :isfirstfrag, "Match the first fragment of a fragmented ipv6 packet"
   feature :ipsec_policy, "Match IPsec policy"
   feature :ipsec_dir, "Match IPsec policy direction"
+  feature :mask, "Ability to match recent rules based on the ipv4 mask"
 
   # provider specific features
   feature :iptables, "The provider provides iptables features."
@@ -323,7 +324,9 @@ Puppet::Type.newtype(:firewall) do
       *tcp*.
     EOS
 
-    newvalues(:tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :gre, :cbt, :all)
+    newvalues(*[:tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ospf, :gre, :cbt, :all].collect do |proto|
+      [proto, "! #{proto}".to_sym]
+    end.flatten)
     defaultto "tcp"
   end
 

--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -77,14 +77,11 @@ module Puppet::Util::Firewall
       proto = 'tcp'
     end
 
-    if value.kind_of?(String)
-      if value.match(/^\d+(-\d+)?$/)
-        return value
-      else
-        return Socket.getservbyname(value, proto).to_s
-      end
+    m = value.to_s.match(/^(!\s+)?(\S+)/)
+    if m[2].match(/^\d+(-\d+)?$/)
+      return "#{m[1]}#{m[2]}"
     else
-      Socket.getservbyname(value.to_s, proto).to_s
+      return "#{m[1]}#{Socket.getservbyname(m[2], proto).to_s}"
     end
   end
 

--- a/spec/acceptance/invert_spec.rb
+++ b/spec/acceptance/invert_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper_acceptance'
+
+describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  before(:all) do
+    iptables_flush_all_tables
+  end
+
+  context "inverting rules" do
+    it 'applies' do
+      pp = <<-EOS
+        class { '::firewall': }
+        firewall { '601 disallow esp protocol':
+          action => 'accept',
+          proto  => '! esp',
+        }
+        firewall { '602 drop NEW external website packets with FIN/RST/ACK set and SYN unset':
+          chain     => 'INPUT',
+          state     => 'NEW',
+          action    => 'drop',
+          proto     => 'tcp',
+          sport     => ['! http', '! 443'],
+          source    => '! 10.0.0.0/8',
+          tcp_flags => '! FIN,SYN,RST,ACK SYN',
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+
+    it 'should contain the rules' do
+      shell('iptables-save') do |r|
+        expect(r.stdout).to match(/-A INPUT ! -p esp -m comment --comment "601 disallow esp protocol" -j ACCEPT/)
+        expect(r.stdout).to match(/-A INPUT ! -s 10\.0\.0\.0\/8 -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m multiport ! --sports 80,443 -m comment --comment "602 drop NEW external website packets with FIN\/RST\/ACK set and SYN unset" -m state --state NEW -j DROP/)
+      end
+    end
+  end
+  context "inverting partial array rules" do
+    it 'raises a failure' do
+      pp = <<-EOS
+        class { '::firewall': }
+        firewall { '603 drop 80,443 traffic':
+          chain     => 'INPUT',
+          action    => 'drop',
+          proto     => 'tcp',
+          sport     => ['! http', '443'],
+        }
+      EOS
+
+      apply_manifest(pp, :expect_failures => true) do |r|
+        expect(r.stderr).to match(/is not prefixed/)
+      end
+    end
+  end
+end

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -473,6 +473,40 @@ ARGS_TO_HASH = {
       :action => 'reject',
     },
   },
+  'disallow_esp_protocol' => {
+    :line   => '-t filter ! -p esp -m comment --comment "063 disallow esp protocol" -j ACCEPT',
+    :table  => 'filter',
+    :params => {
+      :name   => '063 disallow esp protocol',
+      :action => 'accept',
+      :proto  => '! esp',
+    },
+  },
+  'drop_new_packets_without_syn' => {
+    :line   => '-t filter ! -s 10.0.0.0/8 ! -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m comment --comment "064 drop NEW non-tcp external packets with FIN/RST/ACK set and SYN unset" -m state --state NEW -j DROP',
+    :table  => 'filter',
+    :params => {
+      :name      => '064 drop NEW non-tcp external packets with FIN/RST/ACK set and SYN unset',
+      :state     => ['NEW'],
+      :action    => 'drop',
+      :proto     => '! tcp',
+      :source    => '! 10.0.0.0/8',
+      :tcp_flags => '! FIN,SYN,RST,ACK SYN',
+    },
+  },
+  'negate_dport_and_sport' => {
+    :line => '-A nova-compute-FORWARD -s 0.0.0.0/32 -d 255.255.255.255/32 -p udp -m udp ! --sport 68,69 ! --dport 67,66 -j ACCEPT',
+    :table => 'filter',
+    :params => {
+      :action => 'accept',
+      :chain => 'nova-compute-FORWARD',
+      :source => '0.0.0.0/32',
+      :destination => '255.255.255.255/32',
+      :sport => ['! 68','! 69'],
+      :dport => ['! 67','! 66'],
+      :proto => 'udp',
+    },
+  },
 }
 
 # This hash is for testing converting a hash to an argument line.
@@ -939,5 +973,41 @@ HASH_TO_ARGS = {
       :action => 'reject',
     },
     :args => ["-t", :filter, "-p", :all, "-m", "comment", "--comment", "062 REJECT connmark", "-j", "REJECT", "-m", "connmark", "--mark", "0x1"],
+  },
+  'disallow_esp_protocol' => {
+    :params => {
+      :name   => '063 disallow esp protocol',
+      :table  => 'filter',
+      :action => 'accept',
+      :proto  => '! esp',
+    },
+    :args => ["-t", :filter, "!", "-p", :esp, "-m", "comment", "--comment", "063 disallow esp protocol", "-j", "ACCEPT"],
+  },
+  'drop_new_packets_without_syn' => {
+    :params => {
+      :name      => '064 drop NEW non-tcp external packets with FIN/RST/ACK set and SYN unset',
+      :table     => 'filter',
+      :chain     => 'INPUT',
+      :state     => ['NEW'],
+      :action    => 'drop',
+      :proto     => '! tcp',
+      :source    => '! 10.0.0.0/8',
+      :tcp_flags => '! FIN,SYN,RST,ACK SYN',
+    },
+    :args => ["-t", :filter, "!", "-s", "10.0.0.0/8", "!", "-p", :tcp, "-m", "tcp", "!", "--tcp-flags", "FIN,SYN,RST,ACK", "SYN", "-m", "comment", "--comment", "064 drop NEW non-tcp external packets with FIN/RST/ACK set and SYN unset", "-m", "state", "--state", "NEW", "-j", "DROP"]
+  },
+  'negate_dport_and_sport' => {
+    :params => {
+      :name        => '065 negate dport and sport',
+      :table       => 'filter',
+      :action      => 'accept',
+      :chain       => 'nova-compute-FORWARD',
+      :source      => '0.0.0.0/32',
+      :destination => '255.255.255.255/32',
+      :sport       => ['! 68','! 69'],
+      :dport       => ['! 67','! 66'],
+      :proto       => 'udp',
+    },
+    :args => ["-t", :filter, "-s", "0.0.0.0/32", "-d", "255.255.255.255/32", "-p", :udp, "-m", "multiport", "!", "--sports", "68,69", "-m", "multiport", "!", "--dports", "67,66", "-m", "comment", "--comment", "065 negate dport and sport", "-j", "ACCEPT"],
   },
 }

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -315,6 +315,27 @@ describe 'iptables provider' do
     end
   end
 
+  describe 'when inverting rules' do
+    let(:resource) {
+      Puppet::Type.type(:firewall).new({
+        :name  => '040 partial invert',
+        :table       => 'filter',
+        :action      => 'accept',
+        :chain       => 'nova-compute-FORWARD',
+        :source      => '0.0.0.0/32',
+        :destination => '255.255.255.255/32',
+        :sport       => ['! 78','79','http'],
+        :dport       => ['77','! 76'],
+        :proto       => 'udp',
+      })
+    }
+    let(:instance) { provider.new(resource) }
+
+    it 'fails when not all array items are inverted' do
+      expect { instance.insert }.to raise_error Puppet::Error, /but '79', '80' are not prefixed/
+    end
+  end
+
   describe 'when deleting resources' do
     let(:sample_rule) {
       '-A INPUT -s 1.1.1.1 -d 1.1.1.1 -p tcp -m multiport --dports 7061,7062 -m multiport --sports 7061,7062 -j ACCEPT'


### PR DESCRIPTION
iptables has many rule arguments that may be inverted by prefixing with
an exclamation mark. This commit enables inversion for most every
property currently in the firewall provider that supports inversion by
prefixing the value with a bang+space.

Array elements must have all array elements prefixed with a bang+space
otherwise a warning will be raised, as it would look confusing to negate
a single value and then have iptables negate all of them.
