### PR TITLE
Support netfilter-persistent for later versions

### DIFF
--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -191,7 +191,11 @@ module Puppet::Util::Firewall
     when :Debian
       case proto.to_sym
       when :IPv4, :IPv6
-        %w{/usr/sbin/service iptables-persistent save}
+        if Puppet::Util::Package.versioncmp(persist_ver, '1.0') > 0
+          %w{/usr/sbin/service netfilter-persistent save}
+        else
+          %w{/usr/sbin/service iptables-persistent save}
+        end
       end
     when :Debian_manual
       case proto.to_sym


### PR DESCRIPTION
iptables-persistent 1.0 and later is now a plugin module for
netfilter-persistent and does not have its own init script or
service file.  Instead, the save action must be run on the
netfilter-persistent service.
