### PR TITLE
(MODULES-1086) toports is not reqired with jump == REDIRECT

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1090,13 +1090,6 @@ Puppet::Type.newtype(:firewall) do
       end
     end
 
-    if value(:jump).to_s == "REDIRECT"
-      unless value(:toports)
-        self.fail "Parameter jump => REDIRECT missing mandatory toports " \
-          "parameter"
-      end
-    end
-
     if value(:jump).to_s == "MASQUERADE"
       unless value(:table).to_s =~ /nat/
         self.fail "Parameter jump => MASQUERADE only applies to table => nat"


### PR DESCRIPTION
From the man page for REDIRECT and --to-ports: "This specifies a destination port or range of ports to use: without this, the destination port is never altered."
