### PR TITLE
Use puppet() so the module install works better

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -39,7 +39,7 @@ RSpec.configure do |c|
     hosts.each do |host|
       copy_module_to(host, :source => proj_root, :module_name => 'firewall')
       on(host, "/bin/touch #{host['hieraconf']}")
-      on(host, 'puppet module install puppetlabs-stdlib --version 3.2.0', { :acceptable_exit_codes => [0,1] })
+      on host, puppet('module install puppetlabs-stdlib --version 3.2.0'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end


### PR DESCRIPTION
This was failing on SLES10 due to path issues.
