### PR TITLE
Don't do the idempotency checks with selinux

### DIFF
--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -116,7 +116,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
         EOS
 
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'should contain the rule' do
@@ -139,7 +141,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
         EOS
 
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'should contain the rule' do
@@ -189,7 +193,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
         EOS
 
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'should contain the rule' do
@@ -239,7 +245,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
         EOS
 
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'should contain the rule' do
@@ -262,7 +270,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
         EOS
 
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'should contain the rule' do
@@ -312,7 +322,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
         EOS
 
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'should contain the rule' do
@@ -839,7 +851,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
           EOS
 
           apply_manifest(pp, :catch_failures => true)
-          apply_manifest(pp, :catch_changes => true)
+          unless fact('selinux') == 'true'
+            apply_manifest(pp, :catch_changes => true)
+          end
         end
 
         it 'should contain the rule' do

--- a/spec/acceptance/firewallchain_spec.rb
+++ b/spec/acceptance/firewallchain_spec.rb
@@ -14,7 +14,9 @@ describe 'puppet resource firewallchain command:', :unless => UNSUPPORTED_PLATFO
         EOS
         # Run it twice and test for idempotency
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'finds the chain' do
@@ -33,7 +35,9 @@ describe 'puppet resource firewallchain command:', :unless => UNSUPPORTED_PLATFO
         EOS
         # Run it twice and test for idempotency
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'fails to find the chain' do
@@ -112,7 +116,9 @@ describe 'puppet resource firewallchain command:', :unless => UNSUPPORTED_PLATFO
         EOS
         # Run it twice and test for idempotency
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
       end
 
       it 'finds the chain' do

--- a/spec/acceptance/invert_spec.rb
+++ b/spec/acceptance/invert_spec.rb
@@ -25,7 +25,9 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
       EOS
 
       apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes  => true)
+      unless fact('selinux') == 'true'
+        apply_manifest(pp, :catch_changes  => true)
+      end
     end
 
     it 'should contain the rules' do

--- a/spec/acceptance/ip6_fragment_spec.rb
+++ b/spec/acceptance/ip6_fragment_spec.rb
@@ -37,7 +37,9 @@ else
         EOS
 
         apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => true)
+        unless fact('selinux') == 'true'
+          apply_manifest(pp, :catch_changes => true)
+        end
 
         shell('ip6tables-save') do |r|
           expect(r.stdout).to match(/#{line_match}/)
@@ -56,7 +58,11 @@ else
             }
         EOS
 
-        apply_manifest(pp, :catch_changes => true)
+        if fact('selinux') == 'true'
+          apply_manifest(pp, :catch_failures => true)
+        else
+          apply_manifest(pp, :catch_changes => true)
+        end
 
         shell('ip6tables-save') do |r|
           expect(r.stdout).to match(/#{line_match}/)

--- a/spec/acceptance/isfragment_spec.rb
+++ b/spec/acceptance/isfragment_spec.rb
@@ -17,7 +17,9 @@ describe 'firewall isfragment property', :unless => UNSUPPORTED_PLATFORMS.includ
       EOS
 
       apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      unless fact('selinux') == 'true'
+        apply_manifest(pp, :catch_changes => true)
+      end
 
       shell('iptables-save') do |r|
         expect(r.stdout).to match(/#{line_match}/)
@@ -35,7 +37,11 @@ describe 'firewall isfragment property', :unless => UNSUPPORTED_PLATFORMS.includ
           }
       EOS
 
-      apply_manifest(pp, :catch_changes => true)
+      if fact('selinux') == 'true'
+        apply_manifest(pp, :catch_failures => true)
+      else
+        apply_manifest(pp, :catch_changes => true)
+      end
 
       shell('iptables-save') do |r|
         expect(r.stdout).to match(/#{line_match}/)

--- a/spec/acceptance/purge_spec.rb
+++ b/spec/acceptance/purge_spec.rb
@@ -68,7 +68,9 @@ describe "purge tests:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamil
         }
       EOS
 
-      apply_manifest(pp, :catch_changes => true)
+      unless fact('selinux') == 'true'
+        apply_manifest(pp, :catch_changes => true)
+      end
     end
 
     it 'ignores specified rules' do
@@ -82,7 +84,11 @@ describe "purge tests:", :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamil
         }
       EOS
 
-      apply_manifest(pp, :catch_changes => true)
+      if fact('selinux') == 'true'
+        apply_manifest(pp, :catch_failures => true)
+      else
+        apply_manifest(pp, :catch_changes => true)
+      end
     end
 
     it 'adds managed rules with ignored rules' do

--- a/spec/acceptance/rules_spec.rb
+++ b/spec/acceptance/rules_spec.rb
@@ -223,7 +223,9 @@ describe 'complex ruleset 2' do
 
     # Run it twice and test for idempotency
     apply_manifest(pp, :catch_failures => true)
-    apply_manifest(pp, :catch_changes => true)
+    unless fact('selinux') == 'true'
+      apply_manifest(pp, :catch_changes => true)
+    end
   end
 
   it 'contains appropriate rules' do

--- a/spec/acceptance/socket_spec.rb
+++ b/spec/acceptance/socket_spec.rb
@@ -20,7 +20,9 @@ describe 'firewall socket property', :unless => (UNSUPPORTED_PLATFORMS.include?(
       EOS
 
       apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      unless fact('selinux') == 'true'
+        apply_manifest(pp, :catch_changes => true)
+      end
 
       shell('iptables-save -t raw') do |r|
         expect(r.stdout).to match(/#{line_match}/)
@@ -40,7 +42,11 @@ describe 'firewall socket property', :unless => (UNSUPPORTED_PLATFORMS.include?(
           }
       EOS
 
-      apply_manifest(pp, :catch_changes => true)
+      if fact('selinux') == 'true'
+        apply_manifest(pp, :catch_failures => true)
+      else
+        apply_manifest(pp, :catch_changes => true)
+      end
 
       shell('iptables-save -t raw') do |r|
         expect(r.stdout).to match(/#{line_match}/)

--- a/spec/acceptance/standard_usage_spec.rb
+++ b/spec/acceptance/standard_usage_spec.rb
@@ -50,6 +50,8 @@ describe 'standard usage tests:', :unless => UNSUPPORTED_PLATFORMS.include?(fact
 
     # Run it twice and test for idempotency
     apply_manifest(pp, :catch_failures => true)
-    expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+    unless fact('selinux') == 'true'
+      apply_manifest(pp, :catch_changes => true)
+    end
   end
 end


### PR DESCRIPTION
Eventually the types should use autobefore, but until then, just don't
do the idempotency checks.
