### PR TITLE
Doesn't actually support OEL5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]


### PR DESCRIPTION
There are weird interactions between the version of iptables and the
kernel on OEL5.
