### PR TITLE
(MODULES-464) Add netmap feature

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -344,7 +344,7 @@ This type enables you to manage firewall rules within Puppet.
 * `iptables`: Iptables type provider
     * Required binaries: `iptables-save`, `iptables`.
     * Default for `kernel` == `linux`.
-    * Supported features: `address_type`, `connection_limiting`, `dnat`, `icmp_match`, `interface_match`, `iprange`, `ipsec_dir`, `ipsec_policy`, `iptables`, `isfragment`, `log_level`, `log_prefix`, `mark`, `owner`, `pkttype`, `rate_limiting`, `recent_limiting`, `reject_type`, `snat`, `socket`, `state_match`, `tcp_flags`.
+    * Supported features: `address_type`, `connection_limiting`, `dnat`, `icmp_match`, `interface_match`, `iprange`, `ipsec_dir`, `ipsec_policy`, `iptables`, `isfragment`, `log_level`, `log_prefix`, `mark`, `owner`, `pkttype`, `rate_limiting`, `recent_limiting`, `reject_type`, `snat`, `socket`, `state_match`, `tcp_flags`, `netmap`.
 
 **Autorequires:**
 
@@ -407,6 +407,8 @@ If Puppet is managing the iptables or iptables-persistent packages, and the prov
 * `state_match`: The ability to match stateful firewall states.
 
 * `tcp_flags`: The ability to match on particular TCP flag settings.
+
+* `netmap`: The ability to map entire subnets via source or destination nat rules.
 
 #### Parameters
 
@@ -627,6 +629,8 @@ firewall { '101 blacklist strange traffic':
 * `toports`: For DNAT this is the port that will replace the destination port. Requires the `dnat` feature.
 
 * `tosource`: When using `jump => 'SNAT'`, you can specify the new source address using this parameter. Requires the `snat` feature.
+
+* `to`: When using `jump => 'NETMAP'`, you can specify a source or destination subnet to nat to. Requires the `netmap` feature`.
 
 * `uid`: UID or Username owner matching rule. Accepts a string argument only, as iptables does not accept multiple uid in a single statement. Requires the `owner` feature.
 

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -12,6 +12,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   has_feature :recent_limiting
   has_feature :snat
   has_feature :dnat
+  has_feature :netmap
   has_feature :interface_match
   has_feature :icmp_match
   has_feature :owner
@@ -102,6 +103,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :todest           => "--to-destination",
     :toports          => "--to-ports",
     :tosource         => "--to-source",
+    :to               => "--to",
     :uid              => "-m owner --uid-owner",
   }
 
@@ -156,7 +158,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :dst_type, :src_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy,
     :state, :ctstate, :icmp, :limit, :burst, :recent, :rseconds, :reap,
     :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :jump, :todest,
-    :tosource, :toports, :random, :log_prefix, :log_level, :reject, :set_mark,
+    :tosource, :toports, :to, :random, :log_prefix, :log_level, :reject, :set_mark,
     :connlimit_above, :connlimit_mask, :connmark
   ]
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -34,6 +34,7 @@ Puppet::Type.newtype(:firewall) do
   feature :recent_limiting, "The netfilter recent module"
   feature :snat, "Source NATing"
   feature :dnat, "Destination NATing"
+  feature :netmap, "NET MAPping"
   feature :interface_match, "Interface matching"
   feature :icmp_match, "Matching ICMP types"
   feature :owner, "Matching owners"
@@ -466,6 +467,12 @@ Puppet::Type.newtype(:firewall) do
   newproperty(:toports, :required_features => :dnat) do
     desc <<-EOS
       For DNAT this is the port that will replace the destination port.
+    EOS
+  end
+
+  newproperty(:to, :required_features => :netmap) do
+    desc <<-EOS
+      For NETMAP this will replace the destination IP
     EOS
   end
 

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -219,7 +219,7 @@ describe firewall do
     end
   end
 
-  [:tosource, :todest].each do |addr|
+  [:tosource, :todest, :to].each do |addr|
     describe addr do
       it "should accept #{addr} value as a string" do
         @resource[addr] = '127.0.0.1'


### PR DESCRIPTION
(#464) Add the ability to manage netmap rules.

Change resource_map in iptables provider to map "--to" parameter, which allows for parsing of existing netmap rules in rules_to_hash method.

Change resource_list in iptables provider to map append "--to" parameter when inserting netmap rules.

Add firewall type property "to".

Add feature netmap.

Example:
firewall { "151 NAT rules":
  ensure     => "present",
  chain      => "PREROUTING",
  jump       => "NETMAP",
  destination => "10.168.34.0/24",
  to => "192.168.34.0/24",
  table => "nat",
  source => "192.168.1.0/24",
  proto => "all",
}
