### PR TITLE
Don't arbitrarily limit set_mark to certain chains

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1066,10 +1066,9 @@ Puppet::Type.newtype(:firewall) do
 
     if value(:set_mark)
       unless value(:jump).to_s  =~ /MARK/ &&
-             value(:chain).to_s =~ /PREROUTING|OUTPUT/ &&
              value(:table).to_s =~ /mangle/
         self.fail "Parameter set_mark only applies to " \
-          "the PREROUTING or OUTPUT chain of the mangle table and when jump => MARK"
+          "the mangle table and when jump => MARK"
       end
     end
 


### PR DESCRIPTION
set_mark is currently limited to PREROUTING or OUTPUT chain, i.e. something like the following isn't accepted:

``` puppet
    firewallchain { 'from_mesh:mangle:IPv4':
        ensure  => present,
    }

    firewall { '900 mark mesh to vpn traffic':
        table           => 'mangle',
        chain           => 'from_mesh',
        proto           => 'all',
        jump            => 'MARK',
        set_mark        => '0x2342/0xffffffff',
    }
```

... however it's perfectly valid wrt. iptables. 
