### PR TITLE
MODULES-556: tcp_flags support for ip6tables

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -88,6 +88,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :stat_probability => '--probability',
     :state            => "-m state --state",
     :table            => "-t",
+    :tcp_flags        => "-m tcp --tcp-flags",
     :todest           => "--to-destination",
     :toports          => "--to-ports",
     :tosource         => "--to-source",
@@ -133,7 +134,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   # I put it when calling the command. So compability with manual changes
   # not provided with current parser [georg.koester])
   @resource_list = [:table, :source, :destination, :iniface, :outiface,
-    :proto, :ishasmorefrags, :islastfrag, :isfirstfrag, :gid, :uid, :sport, :dport,
+    :proto, :ishasmorefrags, :islastfrag, :isfirstfrag, :tcp_flags, :gid, :uid, :sport, :dport,
     :port, :pkttype, :name, :state, :ctstate, :icmp, :hop_limit, :limit, :burst,
     :recent, :rseconds, :reap, :rhitcount, :rttl, :rname, :rsource, :rdest,
     :jump, :todest, :tosource, :toports, :log_level, :log_prefix, :reject,

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -1092,6 +1092,30 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
         end
       end
     end
+
+    describe 'tcp_flags' do
+      context 'FIN,SYN ACK' do
+        it 'applies' do
+          pp = <<-EOS
+          class { '::firewall': }
+          firewall { '593 - test':
+            proto  => tcp,
+            action => accept,
+            tcp_flags => 'FIN,SYN ACK',
+            provider => 'ip6tables',
+          }
+          EOS
+
+          apply_manifest(pp, :catch_failures => true)
+        end
+
+        it 'should contain the rule' do
+          shell('ip6tables-save') do |r|
+            expect(r.stdout).to match(/-A INPUT -p tcp -m tcp --tcp-flags FIN,SYN ACK -m comment --comment "593 - test" -j ACCEPT/)
+          end
+        end
+      end
+    end
   end
 
   describe 'limit' do


### PR DESCRIPTION
tcp_flags was listed as a supported feature for the ip6tables provider,
but it wasn't actually implemented
