### PR TITLE
Fix netmap acceptance tests

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -267,7 +267,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     map_index={}
     @resource_map.each_pair do |map_k,map_v|
       [map_v].flatten.each do |v|
-        ind=values.index(/\s#{v}/)
+        ind=values.index(/\s#{v}\s/)
         next unless ind
         map_index[map_k]=ind
      end

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -1701,10 +1701,17 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
 
       it 'should contain the rule' do
         shell('iptables-save -t nat') do |r|
-          expect(r.stdout).to match(/-A PREROUTING -s 200.200.200.200(\/32)? -p tcp -m comment --comment "611 - test" -j NETMAP --to 192.168.1.1/)
+          expect(r.stdout).to match(/-A PREROUTING -s 200.200.200.200(\/32)? -p tcp -m comment --comment "569 - test" -j NETMAP --to 192.168.1.1/)
         end
       end
     end
+
+     describe 'reset' do
+       it 'deletes all rules' do
+         shell('ip6tables --flush')
+         shell('iptables --flush; iptables -t nat --flush; iptables -t mangle --flush')
+       end
+     end
 
     context 'Source netmap 192.168.1.1' do
       it 'applies' do
@@ -1725,7 +1732,7 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
 
       it 'should contain the rule' do
         shell('iptables-save -t nat') do |r|
-          expect(r.stdout).to match(/-A POSTROUTING -d 200.200.200.200(\/32)? -p tcp -m comment --comment "611 - test" -j NETMAP --to 192.168.1.1/)
+          expect(r.stdout).to match(/-A POSTROUTING -d 200.200.200.200(\/32)? -p tcp -m comment --comment "569 - test" -j NETMAP --to 192.168.1.1/)
         end
       end
     end    


### PR DESCRIPTION
This commit:
- Updates the netmap acceptance tests to have the correct identifying
  comment
- Resets iptables inbetween the two tests since the rules can't be
  changed
- Updates a regex in the iptables provider to check for spaces before
  and after a flag so that "--to" isn't confused with "--to-port"
