### PR TITLE
fixed pkg and service name on Ubuntu 14.10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,15 @@ class firewall::params {
         $package_name = 'iptables-persistent'
       }
     }
+    'Ubuntu' : {
+      if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '14.10') >= 0 {
+        $service_name = 'netfilter-persistent'
+        $package_name = 'netfilter-persistent'
+      } else {
+        $service_name = 'iptables-persistent'
+        $package_name = 'iptables-persistent'
+      }
+    }
     default: {
       $package_name = undef
       $service_name = 'iptables'


### PR DESCRIPTION
Fix an issue with init-script name on Ubuntu 14.10 (was renamed to netfilter-persistent)