### PR TITLE
MODULES-1552 - Issues parsing `-m (tcp|udp)` rules

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -233,7 +233,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     # the actual rule will have the ! mark before the option.
     values = values.gsub(/(!)\s*(-\S+)\s*(\S*)/, '\2 "\1 \3"')
     # The match extension for tcp & udp are optional and throws off the @resource_map.
-    values = values.gsub(/-m (tcp|udp) (--(s|d)port|-m multiport)/, '\2')
+    values = values.gsub(/(?!-m tcp --tcp-flags)-m (tcp|udp) /, '')
     # '--pol ipsec' takes many optional arguments; we cheat again by adding " around them
     values = values.sub(/
         --pol\sipsec

--- a/spec/acceptance/resource_cmd_spec.rb
+++ b/spec/acceptance/resource_cmd_spec.rb
@@ -133,6 +133,21 @@ describe 'puppet resource firewall command:', :unless => UNSUPPORTED_PLATFORMS.i
     end
   end
 
+  context 'accepts rules with -m (tcp|udp) without dport/sport' do
+    before :all do
+      iptables_flush_all_tables
+      shell('iptables -A INPUT -s 10.0.0.0/8 -p udp -m udp -j ACCEPT')
+    end
+
+    it do
+      shell('puppet resource firewall') do |r|
+        r.exit_code.should be_zero
+        # don't check stdout, testing preexisting rules, output is normal
+        r.stderr.should be_empty
+      end
+    end
+  end
+
   # version of iptables that ships with el5 doesn't work with the
   # ip6tables provider
   if default['platform'] !~ /el-5/


### PR DESCRIPTION
The parser was arbitrarily requiring `--(d|s)port` or `-m multiport` with
`-m tcp` or `-m udp`.