### PR TITLE
Lookup username from uid

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -179,6 +179,11 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     properties[:ensure] != :absent
   end
 
+  def uid
+    require 'etc'
+    return properties[:uid] == resource[:uid] || Etc.getpwuid(properties[:uid]).name == resource[:uid]
+  end
+
   # Flush the property hash once done.
   def flush
     debug("[flush]")


### PR DESCRIPTION
When using the uid feature of the firewall module,
it did not work with string based usernames as
documented.

The uid propery always synchronized with a message of
<number> does not match <username>.

This code overrides the uid getter method to perform
a check of both the data from the property hash as well
as using that data (assuming it is a uid) to resolve the
username.

While this patch is pretty simple, I have only tested it
on Ubuntu 14.04. I am not sure if it could be problematic
with other versions.

I have not yet written tests b/c I wanted to submit
my proposed fix for discussion while I get those
written.