### PR TITLE
Lookup username from uuid

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -693,6 +693,11 @@ Puppet::Type.newtype(:firewall) do
       only, as iptables does not accept multiple uid in a single
       statement.
     EOS
+    def insync?(is)
+      require 'etc'
+      return is.to_s == @should.first.to_s || Etc.getpwuid(Integer(is)).name == @should.first.to_s
+    end
+
   end
 
   newproperty(:gid, :required_features => :owner) do


### PR DESCRIPTION
When using the uid feature of the firewall module,
it did not work with string based usernames as
documented.

The uid propery always synchronized with a message of
<number> does not match <username>.

This code overrides the uid getter method to perform
a check of both the data from the property hash as well
as using that data (assuming it is a uid) to resolve the
username.

While this patch is pretty simple, I have only tested it
on Ubuntu 14.04. I am not sure if it could be problematic
with other versions.

I have not yet written tests b/c I wanted to submit
my proposed fix for discussion while I get those
written.