### PR TITLE
Add missing :mask on ip6tables provider

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -26,6 +26,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   has_feature :iprange
   has_feature :ipsec_dir
   has_feature :ipsec_policy
+  has_feature :mask
 
   optional_commands({
     :ip6tables      => 'ip6tables',
@@ -83,6 +84,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :limit            => "-m limit --limit",
     :log_level        => "--log-level",
     :log_prefix       => "--log-prefix",
+    :mask             => "--mask",
     :name             => "-m comment --comment",
     :mac_source       => ["-m mac --mac-source", "--mac-source"],
     :outiface         => "-o",
@@ -169,8 +171,8 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :tcp_flags, :gid, :uid, :mac_source, :sport, :dport, :port, :dst_type,
     :src_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy, :state,
     :ctstate, :icmp, :hop_limit, :limit, :burst, :recent, :rseconds, :reap,
-    :rhitcount, :rttl, :rname, :rsource, :rdest, :jump, :todest, :tosource,
-    :toports, :log_level, :log_prefix, :reject, :set_mark, :connlimit_above,
-    :connlimit_mask, :connmark]
+    :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :jump, :todest,
+    :tosource, :toports, :log_level, :log_prefix, :reject, :set_mark,
+    :connlimit_above, :connlimit_mask, :connmark]
 
 end


### PR DESCRIPTION
The :mask option was missing in the ip6tables provider which prevented it from correctly working with the recent module with the following error:

Could not evaluate: Parser error: rttl was meant to be a boolean but received value: "--mask."