### PR TITLE
Fixing regressions for Amazon Linux since RH7 support was added

### DIFF
--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -169,7 +169,7 @@ module Puppet::Util::Firewall
     end
 
     # RHEL 7 and newer also use systemd to persist iptable rules
-    if os_key == 'RedHat' && ['RedHat','CentOS','Scientific','SL','SLC','Ascendos','CloudLinux','PSBM','OracleLinux','OVS','OEL','Amazon','XenServer'].include?(Facter.value(:operatingsystem)) && Facter.value(:operatingsystemrelease).to_i >= 7
+    if os_key == 'RedHat' && ['RedHat','CentOS','Scientific','SL','SLC','Ascendos','CloudLinux','PSBM','OracleLinux','OVS','OEL','XenServer'].include?(Facter.value(:operatingsystem)) && Facter.value(:operatingsystemrelease).to_i >= 7
       os_key = 'Fedora'
     end
 

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -22,8 +22,9 @@ class firewall::linux::redhat (
   # RHEL 7 and later and Fedora 15 and later require the iptables-services
   # package, which provides the /usr/libexec/iptables/iptables.init used by
   # lib/puppet/util/firewall.rb.
-  if ($::operatingsystem != 'Fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)
-  or ($::operatingsystem == 'Fedora' and versioncmp($::operatingsystemrelease, '15') >= 0) {
+  if ($::operatingsystem != 'Amazon')
+  and (($::operatingsystem != 'Fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)
+  or  ($::operatingsystem == 'Fedora' and versioncmp($::operatingsystemrelease, '15') >= 0)) {
     service { 'firewalld':
       ensure => stopped,
       enable => false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,10 @@ class firewall::params {
   case $::osfamily {
     'RedHat': {
       case $::operatingsystem {
+        'Amazon': {
+          $service_name = 'iptables'
+          $package_name = undef
+        }
         'Archlinux': {
           $service_name = ['iptables','ip6tables']
           $package_name = undef


### PR DESCRIPTION
By adding support for RH7, Amazon was getting incorrectly grouped with those newer operating systems. Amazon Linux is still using the RH6 way to do things making the module unusable on all Amazon systems. I'm adding exceptions for Amazon as the conditions for RH7 were incorrectly catching Amazon Linux because the operatingsystemrelease YYYY.MM will always evaluate to `true`