### PR TITLE
MODULES-1453 - overly aggressive gsub

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -438,7 +438,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
 
   def delete_args
     # Split into arguments
-    line = properties[:line].gsub(/\-A/, '-D').split(/\s(?=(?:[^"]|"[^"]*")*$)/).map{|v| v.gsub(/"/, '')}
+    line = properties[:line].gsub(/\-A /, '-D ').split(/\s(?=(?:[^"]|"[^"]*")*$)/).map{|v| v.gsub(/"/, '')}
     line.unshift("-t", properties[:table])
   end
 

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -2207,4 +2207,43 @@ describe 'firewall type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
     end
   end
 
+  context 'log_prefix containing -A' do
+    it 'adds the rule' do
+      pp = <<-EOS
+      class { '::firewall': }
+      firewall { '700 - test':
+        jump       => 'LOG',
+        log_prefix => 'FW-A-INPUT: ',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'should contain the rule' do
+      shell('iptables-save') do |r|
+        expect(r.stdout).to match(/-A INPUT -p tcp -m comment --comment "100 foo bar" -j LOG --log-prefix "FW-A-INPUT: "/)
+      end
+    end
+
+    it 'removes the rule' do
+      pp = <<-EOS
+      class { '::firewall': }
+      firewall { '700 - test':
+        ensure     => absent,
+        jump       => 'LOG',
+        log_prefix => 'FW-A-INPUT: ',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'should not contain the rule' do
+      shell('iptables-save') do |r|
+        expect(r.stdout).to_not match(/-A INPUT -p tcp -m comment --comment "100 foo bar" -j LOG --log-prefix "FW-A-INPUT: "/)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Make sure there's a space after '-A' before gsubbing with '-D'. Was
causing issues with `ensure => absent` and `log_prefix =>
'FW-A-<whatever>'`