### PR TITLE
Fix os-family for ArchLinux.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,10 +6,6 @@ class firewall::params {
           $service_name = 'iptables'
           $package_name = undef
         }
-        'Archlinux': {
-          $service_name = ['iptables','ip6tables']
-          $package_name = undef
-        }
         'Fedora': {
           if versioncmp($::operatingsystemrelease, '15') >= 0 {
             $package_name = 'iptables-services'
@@ -56,6 +52,10 @@ class firewall::params {
         }
       }
     }
+    'Archlinux': {
+      $service_name = ['iptables','ip6tables']
+      $package_name = undef
+     }
     'Gentoo': {
       $service_name = ['iptables','ip6tables']
       $package_name = 'net-firewall/iptables'


### PR DESCRIPTION
Starting & enabling service(s) didn't work, because ArchLinux has own os-family.
