### PR TITLE
Enable firewall rule persistence for Red Hat-derived OSes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -345,6 +345,7 @@ Performs the basic setup tasks required for using the firewall resources.
 At the moment this takes care of:
 
 * iptables-persistent package installation
+* On Red Hat-derived systems, managing /etc/sysconfig/iptables-config
 
 Include the `firewall` class for nodes that need to use the resources in this module:
 

--- a/files/iptables-config
+++ b/files/iptables-config
@@ -1,0 +1,56 @@
+# This file is managed by Puppet
+
+# Load additional iptables modules (nat helpers)
+#   Default: -none-
+# Space separated list of nat helpers (e.g. 'ip_nat_ftp ip_nat_irc'), which
+# are loaded after the firewall rules are applied. Options for the helpers are
+# stored in /etc/modprobe.conf.
+IPTABLES_MODULES=""
+
+# Unload modules on restart and stop
+#   Value: yes|no,  default: yes
+# This option has to be 'yes' to get to a sane state for a firewall
+# restart or stop. Only set to 'no' if there are problems unloading netfilter
+# modules.
+IPTABLES_MODULES_UNLOAD="yes"
+
+# Save current firewall rules on stop.
+#   Value: yes|no,  default: no
+# Saves all firewall rules to /etc/sysconfig/iptables if firewall gets stopped
+# (e.g. on system shutdown).
+IPTABLES_SAVE_ON_STOP="yes"
+
+# Save current firewall rules on restart.
+#   Value: yes|no,  default: no
+# Saves all firewall rules to /etc/sysconfig/iptables if firewall gets
+# restarted.
+IPTABLES_SAVE_ON_RESTART="yes"
+
+# Save (and restore) rule and chain counter.
+#   Value: yes|no,  default: no
+# Save counters for rules and chains to /etc/sysconfig/iptables if
+# 'service iptables save' is called or on stop or restart if SAVE_ON_STOP or
+# SAVE_ON_RESTART is enabled.
+IPTABLES_SAVE_COUNTER="no"
+
+# Numeric status output
+#   Value: yes|no,  default: yes
+# Print IP addresses and port numbers in numeric format in the status output.
+IPTABLES_STATUS_NUMERIC="yes"
+
+# Verbose status output
+#   Value: yes|no,  default: yes
+# Print info about the number of packets and bytes plus the "input-" and
+# "outputdevice" in the status output.
+IPTABLES_STATUS_VERBOSE="no"
+
+# Status output with numbered lines
+#   Value: yes|no,  default: yes
+# Print a counter/number for every rule in the status output.
+IPTABLES_STATUS_LINENUMBERS="yes"
+
+# Reload sysctl settings on start and restart
+#   Default: -none-
+# Space separated list of sysctl items which are to be reloaded on start.
+# List items will be matched by fgrep.
+#IPTABLES_SYSCTL_LOAD_LIST=".nf_conntrack .bridge-nf"

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -52,4 +52,12 @@ class firewall::linux::redhat (
     group  => 'root',
     mode   => '0600',
   }
+
+  file { '/etc/sysconfig/iptables-config':
+    ensure => present,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0600',
+    source => 'puppet:///modules/puppetlabs-firewall/iptables-config',
+  }
 }


### PR DESCRIPTION
Currently on RHEL (v6), firewall config is not saved on service stop/restart. Use of this module causes an awkward period on system boot where the firewall is empty until Puppet runs. You get the same problem when restarting iptables for whatever reason. There are two options in `/etc/sysconfig/iptables-config` which help here:


    # Save current firewall rules on stop.
    #   Value: yes|no,  default: no
    # Saves all firewall rules to /etc/sysconfig/iptables if firewall gets stopped
    # (e.g. on system shutdown).
    IPTABLES_SAVE_ON_STOP="yes"
    
    # Save current firewall rules on restart.
    #   Value: yes|no,  default: no
    # Saves all firewall rules to /etc/sysconfig/iptables if firewall gets
    # restarted.
    IPTABLES_SAVE_ON_RESTART="yes"

This module manages `/etc/sysconfig/iptables-config` in order to change these values to "yes".

To me, this change makes the module behave like I expect, but I'm not sure if you agree, or what the current behaviour is on other OSes.