### PR TITLE
(MODULES-1976) Revise rule name validation for ruby 1.9

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -188,7 +188,7 @@ All rules employ a numbering system in the resource's title that is used for ord
 
 You can place default rules in either `my_fw::pre` or `my_fw::post`, depending on when you would like them to run. Rules placed in the `pre` class will run first, and rules in the `post` class, last.
 
-In iptables, the title of the rule is stored using the comment feature of the underlying firewall subsystem. Values must match '/^\d+[[:alpha:][:digit:][:punct:][:space:]]+$/'.
+In iptables, the title of the rule is stored using the comment feature of the underlying firewall subsystem. Values must match '/^\d+[[:graph:][:space:]]+$/'.
 
 ####Examples of Default Rules
 
@@ -546,7 +546,7 @@ firewall { '999 this runs last':
 }
  ```
 
-  Depending on the provider, the name of the rule can be stored using the comment feature of the underlying firewall subsystem. Values must match '/^\d+[[:alpha:][:digit:][:punct:][:space:]]+$/'.
+  Depending on the provider, the name of the rule can be stored using the comment feature of the underlying firewall subsystem. Values must match '/^\d+[[:graph:][:space:]]+$/'.
 
 * `outiface`: Output interface to filter on. Values must match '/^!?\s?[a-zA-Z0-9\-\._\+\:]+$/'.  Requires the `interface_match` feature.  Supports interface alias (eth0:0) and negation.
 

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -444,9 +444,9 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     if ! hash[:name]
       num = 9000 + counter
       hash[:name] = "#{num} #{Digest::MD5.hexdigest(line)}"
-    elsif not /^\d+[[:alpha:][:digit:][:punct:][:space:]]+$/ =~ hash[:name]
+    elsif not /^\d+[[:graph:][:space:]]+$/ =~ hash[:name]
       num = 9000 + counter
-      hash[:name] = "#{num} #{/([[:alpha:][:digit:][:punct:][:space:]]+)/.match(hash[:name])[1]}"
+      hash[:name] = "#{num} #{/([[:graph:][:space:]]+)/.match(hash[:name])[1]}"
     end
 
     # Iptables defaults to log_level '4', so it is omitted from the output of iptables-save.

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -90,7 +90,7 @@ Puppet::Type.newtype(:firewall) do
     isnamevar
 
     # Keep rule names simple - they must start with a number
-    newvalues(/^\d+[[:alpha:][:digit:][:punct:][:space:]]+$/)
+    newvalues(/^\d+[[:graph:][:space:]]+$/)
   end
 
   newproperty(:action) do

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -738,6 +738,13 @@ HASH_TO_ARGS = {
     },
     :args => ['-t', :filter, '-s', '192.168.0.1/32', '-p', :tcp, '-m', 'comment', '--comment', '000 allow from 192.168.0.1, please'],
   },
+  'comment_string_character_validation_2' => {
+    :params => {
+      :name => "000 allow symbols ( $+<=>^`|~ ) in ruby >= 1.9",
+      :table => 'filter',
+    },
+    :args => ['-t', :filter, '-p', :tcp, '-m', 'comment', '--comment', '000 allow symbols ( $+<=>^`|~ ) in ruby >= 1.9'],
+  },
   'port_property' => {
     :params => {
       :name => '001 port property',


### PR DESCRIPTION
Note: This test will only fail for ruby 1.9 and above.  I was unable to find a way to reproduce the character encoding functionality introduced in 1.9 on previous versions of ruby in order to construct a test that is useful in those environments.