### PR TITLE
(MODULES-1984) Perform daemon-reload on systemd

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -39,6 +39,14 @@ class firewall::linux::redhat (
     }
   }
 
+  if ($::operatingsystem != 'Amazon')
+  and (($::operatingsystem != 'Fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)
+  or  ($::operatingsystem == 'Fedora' and versioncmp($::operatingsystemrelease, '15') >= 0)) {
+    exec { '/usr/bin/systemctl daemon-reload':
+      require   => Package[$package_name],
+    }
+  }
+
   service { $service_name:
     ensure    => $ensure,
     enable    => $enable,


### PR DESCRIPTION
This commit patches the `manifests/linux/redhat.pp` manifest to
perform a `systemctl daemon-reload` exec on platforms that also
contain firewalld.

Prior to this commit, Specifically on Centos 7, if the systemd
deamon is not reloaded then the iptables service fails to start
because it cannot see the systemd Unit for that service.

This patch refreshes the daemon's list of Units and allows the
service to start as expected.