### PR TITLE
(MODULES-2000) netfilter-persistent systems need iptables-persistent pkg

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,30 +29,26 @@ class firewall::params {
       }
     }
     'Debian': {
+      $package_name = 'iptables-persistent'
       case $::operatingsystem {
         'Debian': {
           if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
             $service_name = 'netfilter-persistent'
-            $package_name = 'netfilter-persistent'
           } else {
             $service_name = 'iptables-persistent'
-            $package_name = 'iptables-persistent'
           }
 
         }
         'Ubuntu': {
           if versioncmp($::operatingsystemrelease, '14.10') >= 0 {
             $service_name = 'netfilter-persistent'
-            $package_name = 'netfilter-persistent'
           } else {
             $service_name = 'iptables-persistent'
-            $package_name = 'iptables-persistent'
           }
 
         }
         default: {
           $service_name = 'iptables-persistent'
-          $package_name = 'iptables-persistent'
         }
       }
     }

--- a/spec/unit/classes/firewall_linux_debian_spec.rb
+++ b/spec/unit/classes/firewall_linux_debian_spec.rb
@@ -35,13 +35,13 @@ describe 'firewall::linux::debian', :type => :class do
         :operatingsystem       => 'Debian',
         :operatingsystemrelease => 'jessie/sid'
     }}
-    it { should contain_package('netfilter-persistent').with(
+    it { should contain_package('iptables-persistent').with(
       :ensure => 'present'
     )}
     it { should contain_service('netfilter-persistent').with(
       :ensure   => nil,
       :enable   => 'true',
-      :require  => 'Package[netfilter-persistent]'
+      :require  => 'Package[iptables-persistent]'
     )}
   end
 
@@ -63,13 +63,13 @@ describe 'firewall::linux::debian', :type => :class do
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '8.0'
     }}
-    it { should contain_package('netfilter-persistent').with(
+    it { should contain_package('iptables-persistent').with(
       :ensure => 'present'
     )}
     it { should contain_service('netfilter-persistent').with(
       :ensure   => nil,
       :enable   => 'true',
-      :require  => 'Package[netfilter-persistent]'
+      :require  => 'Package[iptables-persistent]'
     )}
   end
 


### PR DESCRIPTION
With the changes in #403 and #436, systems Debian >=8 or Ubuntu >= 14.10 now don't have a dependency on `iptables-persistent` package offering the `netfilter-persistent` plugins required for persistence of iptables/iptables6 rules. Without these plugins, the `netfilter-persistent` *service* silently perfoms no action. The `iptables-persistent` *package* depends on the `netfilter-persistent` *package* and will therefore provide the right *service*.