### PR TITLE
Fix Arch Linux support

### DIFF
--- a/manifests/linux/gentoo.pp
+++ b/manifests/linux/gentoo.pp
@@ -1,7 +1,7 @@
 # = Class: firewall::linux::gentoo
 #
 # Manages `iptables` and `ip6tables` services, and creates files used for
-# persistence, on Arch Linux systems.
+# persistence, on Gentoo Linux systems.
 #
 # == Parameters:
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,10 +6,6 @@ class firewall::params {
           $service_name = 'iptables'
           $package_name = undef
         }
-        'Archlinux': {
-          $service_name = ['iptables','ip6tables']
-          $package_name = undef
-        }
         'Fedora': {
           if versioncmp($::operatingsystemrelease, '15') >= 0 {
             $package_name = 'iptables-services'
@@ -61,8 +57,16 @@ class firewall::params {
       $package_name = 'net-firewall/iptables'
     }
     default: {
-      $package_name = undef
-      $service_name = 'iptables'
+      case $::operatingsystem {
+        'Archlinux': {
+          $service_name = ['iptables','ip6tables']
+          $package_name = undef
+        }
+        default: {
+          $service_name = 'iptables'
+          $package_name = undef
+        }
+      }
     }
   }
 }

--- a/spec/unit/classes/firewall_linux_archlinux_spec.rb
+++ b/spec/unit/classes/firewall_linux_archlinux_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'firewall::linux::archlinux', :type => :class do
   let(:facts) do
     {
-      :osfamily        => 'RedHat',
+      :osfamily        => 'Archlinux',
       :operatingsystem => 'Archlinux'
     }
   end


### PR DESCRIPTION
Previously, Arch Linux was incorrectly assumed to be part of the `RedHat` osfamily. It actually has its own osfamily: `Archlinux`. However, this was added in Facter 1.7.0, and previous versions use an osfamily of `Linux`, so we just check the value of operatingsystem.

Based on #504.