### PR TITLE
(MODULES-2118) Fix severe installation hang on jessie.

### DIFF
--- a/manifests/linux/debian.pp
+++ b/manifests/linux/debian.pp
@@ -21,8 +21,14 @@ class firewall::linux::debian (
 ) inherits ::firewall::params {
 
   if $package_name {
+    #Fixes hang while installing iptables-persistent on debian 8
+    exec {'iptables-persistent-debconf':
+        command     => "/bin/echo \"${package_name} ${package_name}/autosave_v4 boolean false\" | /usr/bin/debconf-set-selections && /bin/echo \"${package_name} ${package_name}/autosave_v6 boolean false\" | /usr/bin/debconf-set-selections",
+        refreshonly => true
+    }
     package { $package_name:
-      ensure => present,
+      ensure  => present,
+      require => Exec['iptables-persistent-debconf']
     }
   }
 


### PR DESCRIPTION
On jessie iptables-persistent installation/configuration pops up debconf to ask if the current firewall setup should be saved which leads to puppet hanging and 99% of the time half configured firewall and ssh lockout.

This patch sets the value to false before the install so that debconf doesn't pop up.