### PR TITLE
Fix undefined method 'fact' error with Facter 3.x

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -841,7 +841,7 @@ Puppet::Type.newtype(:firewall) do
       end
 
       # Old iptables does not support a mask. New iptables will expect one.
-      iptables_version = Facter.fact('iptables_version').value
+      iptables_version = Facter.value('iptables_version')
       mask_required = (iptables_version and Puppet::Util::Package.versioncmp(iptables_version, '1.4.1') >= 0)
 
       if mask_required


### PR DESCRIPTION
Using this module with Facter 3.0.1 causes the following error:

```
Error while evaluating a Resource Statement,
Could not autoload puppet/type/firewall:
Could not autoload puppet/provider/firewall/ip6tables:
Could not autoload puppet/provider/firewall/iptables:
undefined method `fact' for Facter:Module
```

It seems that `Factor` no longer has a `fact` method. The fix directly calls the `value` method.