### PR TITLE
Deprecate port parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -621,7 +621,7 @@ firewall { '999 this runs last':
 
 * `pkttype`: Sets the packet type to match. Valid values are: 'unicast', 'broadcast', and'multicast'. Requires the `pkttype` feature.
 
-* `port`: The destination or source port to match for this filter (if the protocol supports ports). Will accept a single element or an array. For some firewall providers you can pass a range of ports in the format: 'start number-end number'. For example, '1-1024' would cover ports 1 to 1024.
+* `port`: *DEPRECATED* The destination or source port to match for this filter (if the protocol supports ports). Will accept a single element or an array. For some firewall providers you can pass a range of ports in the format: 'start number-end number'. For example, '1-1024' would cover ports 1 to 1024.
 
 * `proto`: The specific protocol to match for this rule. This is 'tcp' by default. Valid values are:
   * 'tcp'

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -272,6 +272,8 @@ Puppet::Type.newtype(:firewall) do
 
   newproperty(:port, :array_matching => :all) do
     desc <<-EOS
+      DEPRECATED
+
       The destination or source port to match for this filter (if the protocol
       supports ports). Will accept a single element or an array.
 
@@ -285,6 +287,10 @@ Puppet::Type.newtype(:firewall) do
 
       This would cover ports 1 to 1024.
     EOS
+
+    validate do |value|
+      Puppet.warning("port is deprecated and will be removed. Use dport and/or sport instead.")
+    end
 
     munge do |value|
       @resource.string_to_port(value, :proto)

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -775,14 +775,6 @@ HASH_TO_ARGS = {
     },
     :args => ['-t', :filter, '-p', :tcp, '-m', 'comment', '--comment', '000 allow symbols ( $+<=>^`|~ ) in ruby >= 1.9'],
   },
-  'port_property' => {
-    :params => {
-      :name => '001 port property',
-      :table => 'filter',
-      :port => '80',
-    },
-    :args => ['-t', :filter, '-p', :tcp, '-m', 'multiport', '--ports', '80', '-m', 'comment', '--comment', '001 port property'],
-  },
   'log_level_debug' => {
     :params => {
       :name => '956 INPUT log-level',

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -181,6 +181,13 @@ describe firewall do
     end
   end
 
+  describe 'port deprecated' do
+    it "raises a warning" do
+      expect(Puppet).to receive(:warning).with /port is deprecated/
+      @resource[:port] = "22"
+    end
+  end
+
   [:dst_type, :src_type].each do |addrtype|
     describe addrtype do
       it "should have no default" do


### PR DESCRIPTION
I couldn't find any valid use case for port, and if any valid case did
exist then sport+dport could be used.