### PR TITLE
MODULES-2487 Improve port deprecation warning

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -289,7 +289,7 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     validate do |value|
-      Puppet.warning("port is deprecated and will be removed. Use dport and/or sport instead.")
+      Puppet.warning('Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.')
     end
 
     munge do |value|

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -183,7 +183,7 @@ describe firewall do
 
   describe 'port deprecated' do
     it "raises a warning" do
-      expect(Puppet).to receive(:warning).with /port is deprecated/
+      expect(Puppet).to receive(:warning).with /port to firewall is deprecated/
       @resource[:port] = "22"
     end
   end


### PR DESCRIPTION
When using "port" it currently only throws this warning:

    Warning: port is deprecated and will be removed. Use dport and/or sport instead.

In order to avoid having to grep all your installed module code to figure out which module actually throws this warning: add the module name in the warning.