### PR TITLE
MODULES-2769 - Add security table for iptables.

### DIFF
--- a/lib/puppet/provider/firewallchain/iptables_chain.rb
+++ b/lib/puppet/provider/firewallchain/iptables_chain.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:firewallchain).provide :iptables_chain do
     }
   }
   InternalChains = /^(PREROUTING|POSTROUTING|BROUTING|INPUT|FORWARD|OUTPUT)$/
-  Tables = 'nat|mangle|filter|raw|rawpost|broute'
+  Tables = 'nat|mangle|filter|raw|rawpost|broute|security'
   Nameformat = /^(.+):(#{Tables}):(IP(v[46])?|ethernet)$/
 
   def create

--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -41,7 +41,7 @@ Puppet::Type.newtype(:firewallchain) do
 
     validate do |value|
       if value !~ Nameformat then
-        raise ArgumentError, "Inbuilt chains must be in the form {chain}:{table}:{protocol} where {table} is one of FILTER, NAT, MANGLE, RAW, RAWPOST, BROUTE or empty (alias for filter), chain can be anything without colons or one of PREROUTING, POSTROUTING, BROUTING, INPUT, FORWARD, OUTPUT for the inbuilt chains, and {protocol} being IPv4, IPv6, ethernet (ethernet bridging) got '#{value}' table:'#{$1}' chain:'#{$2}' protocol:'#{$3}'"
+        raise ArgumentError, "Inbuilt chains must be in the form {chain}:{table}:{protocol} where {table} is one of FILTER, NAT, MANGLE, RAW, RAWPOST, BROUTE, SECURITY or empty (alias for filter), chain can be anything without colons or one of PREROUTING, POSTROUTING, BROUTING, INPUT, FORWARD, OUTPUT for the inbuilt chains, and {protocol} being IPv4, IPv6, ethernet (ethernet bridging) got '#{value}' table:'#{$1}' chain:'#{$2}' protocol:'#{$3}'"
       else
         chain = $1
         table = $2
@@ -72,6 +72,10 @@ Puppet::Type.newtype(:firewallchain) do
           end
           if chain =~ /^PREROUTING|POSTROUTING|INPUT|FORWARD|OUTPUT$/
             raise ArgumentError,'BROUTING is the only inbuilt chain allowed on on table \'broute\''
+          end
+        when 'security'
+          if chain =~ /^(PREROUTING|POSTROUTING|BROUTING)$/
+            raise ArgumentError, "INPUT, OUTPUT and FORWARD are the only inbuilt chains that can be used in table 'security'"
           end
         end
         if chain == 'BROUTING' && ( protocol != 'ethernet' || table!='broute')

--- a/spec/unit/puppet/provider/iptables_chain_spec.rb
+++ b/spec/unit/puppet/provider/iptables_chain_spec.rb
@@ -138,6 +138,9 @@ describe 'iptables chain resource parsing' do
      'NAT:mangle:IPv4',
      'NAT:mangle:IPv4',
      'NAT:mangle:IPv4',
+     'security:INPUT:IPv4',
+     'security:FORWARD:IPv4',
+     'security:OUTPUT:IPv4',
      ':$5()*&%\'"^$): :IPv4',
     ]
     allow(provider).to receive(:execute).with(['/sbin/iptables-save']).and_return('
@@ -184,6 +187,9 @@ COMMIT
       'mangle:OUTPUT:IPv6',
       'mangle:POSTROUTING:IPv6',
       'mangle:ff:IPv6',
+      'security:INPUT:IPv6',
+      'security:FORWARD:IPv6',
+      'security:OUTPUT:IPv6',
       ':INPUT:IPv6',
       ':FORWARD:IPv6',
       ':OUTPUT:IPv6',

--- a/spec/unit/puppet/type/firewallchain_spec.rb
+++ b/spec/unit/puppet/type/firewallchain_spec.rb
@@ -30,7 +30,8 @@ describe firewallchain do
      'mangle' => [ 'PREROUTING', 'POSTROUTING', 'INPUT', 'FORWARD', 'OUTPUT' ],
      'filter' => ['INPUT','OUTPUT','FORWARD'],
      'raw' => [ 'PREROUTING', 'OUTPUT'],
-     'broute' => ['BROUTING']
+     'broute' => ['BROUTING'],
+     'security' => ['INPUT','OUTPUT','FORWARD']
     }.each_pair do |table, allowedinternalchains|
       ['IPv4', 'IPv6', 'ethernet'].each do |protocol|
         [ 'test', '$5()*&%\'"^$09):' ].each do |chainname|


### PR DESCRIPTION
This fixes the following error when the built in "security" table is present.

Error: /Stage[main]/Profiles::Firewall::Stateless/Resources[firewallchain]: Failed to generate additional resources using 'generate': Parameter name failed on Firewallchain[INPUT:security:IPv4]: Inbuilt chains must be in the form {chain}:{table}:{protocol} where {table} is one of FILTER, NAT, MANGLE, RAW, RAWPOST, BROUTE or empty (alias for filter), chain can be anything without colons or one of PREROUTING, POSTROUTING, BROUTING, INPUT, FORWARD, OUTPUT for the inbuilt chains, and {protocol} being IPv4, IPv6, ethernet (ethernet bridging) got 'INPUT:security:IPv4' table:'' chain:'' protocol:''

The target system for this fix is CentOS 7, but it should be applicable to any system with a recent kernel/iptables.
https://lwn.net/Articles/267140/
http://www.netfilter.org/projects/iptables/files/changes-iptables-1.4.11.txt

