### PR TITLE
Support IPv6 NAT on Linux 3.7+

### DIFF
--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -59,7 +59,7 @@ Puppet::Type.newtype(:firewallchain) do
           if chain =~ /^(BROUTING|FORWARD)$/
             raise ArgumentError, "PREROUTING, POSTROUTING, INPUT, and OUTPUT are the only inbuilt chains that can be used in table 'nat'"
           end
-          if protocol =~/^(IP(v6)?)?$/
+          if Gem::Version.new(Facter['kernelmajversion'].value) < Gem::Version.new('3.7') and protocol =~/^(IP(v6)?)?$/
             raise ArgumentError, "table nat isn't valid in IPv6. You must specify ':IPv4' as the name suffix"
           end
         when 'raw'

--- a/spec/unit/puppet/type/firewallchain_spec.rb
+++ b/spec/unit/puppet/type/firewallchain_spec.rb
@@ -36,7 +36,13 @@ describe firewallchain do
         [ 'test', '$5()*&%\'"^$09):' ].each do |chainname|
           name = "#{chainname}:#{table}:#{protocol}"
           if table == 'nat' && protocol == 'IPv6'
-            it "should fail #{name}" do
+            it "should accept #{name} for Linux 3.7+" do
+              allow(Facter.fact(:kernelmajversion)).to receive(:value).and_return('3.7')
+              resource[:name] = name
+              resource[:name].should == name
+            end
+            it "should fail #{name} for Linux 2.6" do
+              allow(Facter.fact(:kernelmajversion)).to receive(:value).and_return('2.6')
               expect { resource[:name] = name }.to raise_error(Puppet::Error)
             end
           elsif protocol != 'ethernet' && table == 'broute'


### PR DESCRIPTION
This was added to Linux in http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=58a317f1061c894d2344c0b6a18ab4a64b69b815