### PR TITLE
If iptables-save isn't available then assume that no rules are active

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -313,8 +313,15 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     rules = []
     counter = 1
 
+    # If iptables-save isn't available then assume that no rules are active
+    begin
+      output = iptables_save.split("\n")
+    rescue
+      output = []
+    end
+
     # String#lines would be nice, but we need to support Ruby 1.8.5
-    iptables_save.split("\n").each do |line|
+    output.each do |line|
       unless line =~ /^\#\s+|^\:\S+|^COMMIT|^FATAL/
         if line =~ /^\*/
           table = line.sub(/\*/, "")


### PR DESCRIPTION
The command 'iptables-save' is marked as being an optional command
so the provider shouldn't produce error messages when it is missing

Resolves the following error message which occurs when iptables-save is
not installed on the system yet and resources { 'firewall': purge => true }
  Error: /Stage[main]/Fw/Resources[firewall]: Failed to generate additional resources using 'generate': Command iptables_save is missing