### PR TITLE
(MODULES-2159) ignore the --connlimit-saddr switch when parsing rules

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -364,6 +364,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
         (\s--next)?/x,
         '--pol "ipsec\1\2\3\4\5\6\7\8" '
     )
+    # on some iptables versions, --connlimit-saddr switch is added after the rule is applied
+    values = values.gsub(/--connlimit-saddr/, '')
 
     resource_map = munge_resource_map_from_existing_values(@resource_map, values)
 


### PR DESCRIPTION
Workaround for https://tickets.puppetlabs.com/browse/MODULES-2159 (as described by Greg Murphy in that ticket)

On some distributions (notably on Ubuntu 14.04 and above, and Centos7 and above) the --connlimit-saddr switch is added after the rule is applied causing rule_to_hash to ignore the rule.  Puppet then attempts (and failes) to re-create the rule every time it runs.