### PR TITLE
(MODULES 3932) - We need to call Facter.flush to clear Facter cache

### DIFF
--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -160,6 +160,9 @@ module Puppet::Util::Firewall
 
     # Older iptables-persistent doesn't provide save action.
     if os_key == 'Debian'
+      # We need to call Facter.flush to clear Facter cache as it's possible the cached value will be nil due to the fact
+      # that the iptables-persistent package was potentially installed after the initial Fact gathering.
+      Facter.flush
       persist_ver = Facter.value(:iptables_persistent_version)
       if (persist_ver and Puppet::Util::Package.versioncmp(persist_ver, '0.5.0') < 0)
         os_key = 'Debian_manual'


### PR DESCRIPTION
We need to call Facter.flush to clear Facter cache to get up to date value for :iptables_persistent_version.