### PR TITLE
(MODULES-3079) Add support for goto argument.

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -73,6 +73,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :ipset                 => "-m set --match-set",
     :isfragment            => "-f",
     :jump                  => "-j",
+    :goto                  => "-g",
     :limit                 => "-m limit --limit",
     :log_level             => "--log-level",
     :log_prefix            => "--log-prefix",
@@ -155,7 +156,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :clusterip_new,
   ]
 
-  # Properties that use "-m <ipt module name>" (with the potential to have multiple 
+  # Properties that use "-m <ipt module name>" (with the potential to have multiple
   # arguments against the same IPT module) must be in this hash. The keys in this
   # hash are the IPT module names, with the values being an array of the respective
   # supported arguments for this IPT module.
@@ -255,7 +256,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :src_range, :dst_range, :tcp_flags, :uid, :gid, :mac_source, :sport, :dport, :port,
     :src_type, :dst_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy,
     :state, :ctstate, :icmp, :limit, :burst, :recent, :rseconds, :reap,
-    :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :jump, :clusterip_new, :clusterip_hashmode,
+    :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :jump, :goto, :clusterip_new, :clusterip_hashmode,
     :clusterip_clustermac, :clusterip_total_nodes, :clusterip_local_node, :clusterip_hash_init,
     :clamp_mss_to_pmtu, :gateway, :set_mss, :set_dscp, :set_dscp_class, :todest, :tosource, :toports, :to, :checksum_fill, :random, :log_prefix,
     :log_level, :log_uid, :reject, :set_mark, :match_mark, :mss, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop,
@@ -434,8 +435,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     [:dport, :sport, :port, :state, :ctstate].each do |prop|
       hash[prop] = hash[prop].split(',') if ! hash[prop].nil?
     end
-  
-    ## clean up DSCP class to HEX mappings 
+
+    ## clean up DSCP class to HEX mappings
     valid_dscp_classes = {
       '0x0a' => 'af11',
       '0x0c' => 'af12',

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -374,7 +374,7 @@ Puppet::Type.newtype(:firewall) do
     end.flatten)
     defaultto "tcp"
   end
-  
+
   # tcp-specific
   newproperty(:mss) do
     desc <<-EOS
@@ -469,6 +469,40 @@ Puppet::Type.newtype(:firewall) do
       if ["accept","reject","drop"].include?(value.downcase)
         raise ArgumentError, <<-EOS
           Jump destination should not be one of ACCEPT, REJECT or DROP. Use
+          the action property instead.
+        EOS
+      end
+
+    end
+  end
+
+  newproperty(:goto, :required_features => :iptables) do
+    desc <<-EOS
+      The value for the iptables --goto parameter. Normal values are:
+
+      * QUEUE
+      * RETURN
+      * DNAT
+      * SNAT
+      * LOG
+      * MASQUERADE
+      * REDIRECT
+      * MARK
+
+      But any valid chain name is allowed.
+    EOS
+
+    validate do |value|
+      unless value =~ /^[a-zA-Z0-9\-_]+$/
+        raise ArgumentError, <<-EOS
+          Goto destination must consist of alphanumeric characters, an
+          underscore or a yphen.
+        EOS
+      end
+
+      if ["accept","reject","drop"].include?(value.downcase)
+        raise ArgumentError, <<-EOS
+          Goto destination should not be one of ACCEPT, REJECT or DROP. Use
           the action property instead.
         EOS
       end
@@ -894,7 +928,7 @@ Puppet::Type.newtype(:firewall) do
       Set DSCP Markings.
     EOS
   end
-  
+
   newproperty(:set_dscp_class, :required_features => :iptables) do
     desc <<-EOS
       This sets the DSCP field according to a predefined DiffServ class.

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -79,6 +79,15 @@ ARGS_TO_HASH = {
       :action => nil,
     },
   },
+  'jump_goto' => {
+    :line => '-A w--instance-cfmhvrgpmq6 -g w--default',
+    :table => 'filter',
+    :params => {
+      :goto => "w--default",
+      :action => nil,
+    },
+
+  },
   'source_destination_ipv4_no_cidr' => {
     :line => '-A INPUT -s 1.1.1.1 -d 2.2.2.2 -m comment --comment "000 source destination ipv4 no cidr"',
     :table => 'filter',

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -431,4 +431,3 @@ describe 'ip6tables provider' do
     end
   end
 end
-


### PR DESCRIPTION
Currently puppet throws an error when a (unmanaged) iptables rules contains the `--goto` parameter:

    -A w--instance-cfmhvrgpmq6 -g w--default

    Error: Could not prefetch firewall provider 'iptables': Invalid address from IPAddr.new: -g
    Error: /Firewall[000 accept all icmp]: Could not evaluate: Invalid address from IPAddr.new: -g

This change makes sure puppet doesn't fail. 
