### PR TITLE
match rules with -m ttl

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -339,6 +339,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     # PRE-PARSE CLUDGING
     ####################
 
+    # The match for ttl
+    values = values.gsub(/(!\s+)?-m ttl (!\s+)?--ttl-(eq|lt|gt) [0-9]+/, '')
     # --tcp-flags takes two values; we cheat by adding " around it
     # so it behaves like --comment
     values = values.gsub(/(!\s+)?--tcp-flags (\S*) (\S*)/, '--tcp-flags "\1\2 \3"')

--- a/spec/acceptance/resource_cmd_spec.rb
+++ b/spec/acceptance/resource_cmd_spec.rb
@@ -150,6 +150,21 @@ describe 'puppet resource firewall command:', :unless => UNSUPPORTED_PLATFORMS.i
     end
   end
 
+  context 'accepts rules with -m ttl' do
+    before :all do
+      iptables_flush_all_tables
+      shell('iptables -t nat -A OUTPUT -s 10.0.0.0/8 -p tcp -m ttl ! --ttl-eq 42 -j REDIRECT --to-ports 12299')
+    end
+
+    it do
+      shell('puppet resource firewall') do |r|
+        r.exit_code.should be_zero
+        # don't check stdout, testing preexisting rules, output is normal
+        r.stderr.should be_empty
+      end
+    end
+  end
+
   # version of iptables that ships with el5 doesn't work with the
   # ip6tables provider
   if default['platform'] !~ /el-5/ and default['platform'] !~ /sles-10/


### PR DESCRIPTION
I have the similar issue to #462  and I also fixed that in similar way.

I need to match the rules with -m ttl otherwise puppet will fail with following error:

`Could not prefetch firewall provider 'iptables': Invalid address from IPAddr.new`