### PR TITLE
MODULES-1748 Handle negative physdev-is-bridged

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -348,6 +348,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     values = values.sub(/(!\s+)?--match-set (\S*) (\S*)/, '--match-set "\1\2 \3"')
     # we do a similar thing for negated address masks (source and destination).
     values = values.gsub(/(-\S+) (!)\s?(\S*)/,'\1 "\2 \3"')
+    # catch negated rules with two values
+    values = values.gsub(/(!)\s*(-\S+)\s*-/, '\2 "\1" -')
     # the actual rule will have the ! mark before the option.
     values = values.gsub(/(!)\s*(-\S+)\s*(\S*)/, '\2 "\1 \3"')
     # The match extension for tcp & udp are optional and throws off the @resource_map.
@@ -472,7 +474,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     # Convert booleans removing the previous cludge we did
     @known_booleans.each do |bool|
       if hash[bool] != nil then
-        if hash[bool] != "true" then
+        if hash[bool] != "true" && hash[bool] != "!" then
           raise "Parser error: #{bool} was meant to be a boolean but received value: #{hash[bool]}."
         end
       end
@@ -504,6 +506,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
       :src_range,
       :src_type,
       :state,
+      :physdev_is_bridged,
     ].each do |prop|
       if hash[prop] and hash[prop].is_a?(Array)
         # find if any are negated, then negate all if so

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -590,6 +590,13 @@ ARGS_TO_HASH = {
       :chain             => 'foo-filter',
     },
   },
+  'negative_physdev_is_bridged_with_jump' => {
+    :line => '-A FORWARD -m physdev ! --physdev-is-bridged -j REJECT --reject-with icmp-host-prohibited',
+    :params => {
+      :action            => 'reject',
+      :chain             => 'true',
+    },
+  },
 }
 
 # This hash is for testing converting a hash to an argument line.


### PR DESCRIPTION
With an iptables line like this:

-A FORWARD -m physdev ! --physdev-is-bridged -j REJECT \
--reject-with icmp-host-prohibited

You'd get:

Parser error: physdev_is_bridged was meant to be a
boolean but received value: REJECT.
- The pre-cludge regex's were being over greedy and taking -j as
  part of the quoted value.
- I allowed @known_booleans to also be "!" - perhaps this could
  be done better tho.
- I also added physdev_is_bridged to the rules that can be prefixed
  with a "!".
