### PR TITLE
Pinned rspec_puppet to 2.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,12 @@ group :development, :unit_tests do
   gem 'puppet_facts',              :require => false
   gem 'puppet-blacksmith',         :require => false
   gem 'puppetlabs_spec_helper',    :require => false
-  gem 'rspec-puppet', '>= 2.3.2',  :require => false
+
+  # Modulesync will override the following. This is only a temporary measure until we fix
+  # our tests for rspec-puppet 2.4.0 support.
+  # Actual update work to be done in https://tickets.puppetlabs.com/browse/FM-5035
+  gem 'rspec-puppet', '= 2.3.2',   :require => false
+
   gem 'simplecov',                 :require => false
 end
 group :system_tests do


### PR DESCRIPTION
This is only a temporary measure, as once module-sync runs, this file will be overwritten. This is to make the rspec tests go green until we add support for rspec_puppet 2.4.0

Actual update work to be done in https://tickets.puppetlabs.com/browse/FM-5035