### PR TITLE
(maint) re-add the local nodesets

### DIFF
--- a/spec/acceptance/nodesets/new/aio/debian-8-64mda.yml
+++ b/spec/acceptance/nodesets/new/aio/debian-8-64mda.yml
@@ -1,0 +1,29 @@
+---
+HOSTS:
+  debian-8-amd64-agent:
+    roles:
+    - agent
+    - default
+    platform: debian-8-amd64
+    template: debian-8-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: aio
+  ssh:
+    timeout: 600
+

--- a/spec/acceptance/nodesets/new/aio/redhat-6-64mda.yml
+++ b/spec/acceptance/nodesets/new/aio/redhat-6-64mda.yml
@@ -1,0 +1,28 @@
+---
+HOSTS:
+  redhat-6-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-6-x86_64
+    template: redhat-6-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: aio
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/aio/redhat-7-64mda.yml
+++ b/spec/acceptance/nodesets/new/aio/redhat-7-64mda.yml
@@ -1,0 +1,28 @@
+---
+HOSTS:
+  redhat-7-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: aio
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/aio/ubuntu-1404-64mda.yml
+++ b/spec/acceptance/nodesets/new/aio/ubuntu-1404-64mda.yml
@@ -1,0 +1,28 @@
+---
+HOSTS:
+  ubuntu-1404-agent:
+    roles:
+    - agent
+    - default
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  type: aio
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/centos-5-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/centos-5-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  centos-5-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-5-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/centos-6-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/centos-6-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  centos-6-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/centos-7-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/centos-7-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  centos-7-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: centos-7-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/debian-6-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/debian-6-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  debian-6-amd64-agent:
+    roles:
+    - agent
+    - default
+    platform: debian-6-amd64
+    template: debian-6-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/debian-7-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/debian-7-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  debian-7-amd64-agent:
+    roles:
+    - agent
+    - default
+    platform: debian-7-amd64
+    template: debian-7-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/debian-8-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/debian-8-64mda.yml
@@ -1,0 +1,28 @@
+---
+HOSTS:
+  debian-8-amd64-agent:
+    roles:
+    - agent
+    - default
+    platform: debian-8-amd64
+    template: debian-8-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600
+

--- a/spec/acceptance/nodesets/new/pe/oracle-6-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/oracle-6-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  oracle-6-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-6-x86_64
+    template: oracle-6-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/oracle-7-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/oracle-7-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  oracle-7-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: oracle-7-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/redhat-5-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/redhat-5-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  redhat-5-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-5-x86_64
+    template: redhat-5-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/redhat-6-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/redhat-6-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  redhat-6-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-6-x86_64
+    template: redhat-6-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/redhat-7-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/redhat-7-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  redhat-7-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/scientific-5-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/scientific-5-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  scientific-5-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-5-x86_64
+    template: scientific-5-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/scientific-6-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/scientific-6-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  scientific-6-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-6-x86_64
+    template: scientific-6-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/scientific-7-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/scientific-7-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  scientific-7-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: scientific-7-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/sles-10-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/sles-10-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  sles-10-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: sles-10-x86_64
+    template: sles-10-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/sles-11-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/sles-11-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  sles-11-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: sles-11-x86_64
+    template: sles-11-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/sles-12-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/sles-12-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  sles-12-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: sles-12-x86_64
+    template: sles-12-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/ubuntu-1004-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/ubuntu-1004-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  ubuntu-1004-agent:
+    roles:
+    - agent
+    - default
+    platform: ubuntu-10.04-amd64
+    template: ubuntu-1004-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/ubuntu-1204-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/ubuntu-1204-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  ubuntu-1204-agent:
+    roles:
+    - agent
+    - default
+    platform: ubuntu-12.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1204-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/ubuntu-1404-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/ubuntu-1404-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  ubuntu-1404-agent:
+    roles:
+    - agent
+    - default
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600


### PR DESCRIPTION
These nodesets are required for internal CI; to set the ssh timeout.