### PR TITLE
(maint) Remove nat flush

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,7 +8,7 @@ def iptables_flush_all_tables
 end
 
 def ip6tables_flush_all_tables
-  ['filter', 'nat', 'mangle'].each do |t|
+  ['filter', 'mangle'].each do |t|
     expect(shell("ip6tables -t #{t} -F").stderr).to eq("")
   end
 end


### PR DESCRIPTION
The man page says it's not implemented for ip6tables.

This was broken by #622 because previously there was an `ip6tables -t nat --flush` that would run and always fail, but the `shell()` call didn't fail because only the LAST return code would be returned (that of `ip6tables -t mangle --flush`).