### PR TITLE
(Modules 3329) Add support for iptables length and string extensions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -410,12 +410,12 @@ This type enables you to manage firewall rules within Puppet.
 
  * `ip6tables`: Ip6tables type provider
     * Required binaries: `ip6tables-save`, `ip6tables`.
-    * Supported features: `address_type`, `connection_limiting`, `dnat`, `hop_limiting`, `icmp_match`, `interface_match`, `iprange`, `ipsec_dir`, `ipsec_policy`, `ipset`, `iptables`, `isfirstfrag`, `ishasmorefrags`, `islastfrag`, `log_level`, `log_prefix`, `log_uid`, `mark`, `mask`, `mss`, `owner`, `pkttype`, `rate_limiting`, `recent_limiting`, `reject_type`, `snat`, `socket`, `state_match`, `tcp_flags`.
+    * Supported features: `address_type`, `connection_limiting`, `dnat`, `hop_limiting`, `icmp_match`, `interface_match`, `iprange`, `ipsec_dir`, `ipsec_policy`, `ipset`, `iptables`, `isfirstfrag`, `ishasmorefrags`, `islastfrag`, `length`, `log_level`, `log_prefix`, `log_uid`, `mark`, `mask`, `mss`, `owner`, `pkttype`, `rate_limiting`, `recent_limiting`, `reject_type`, `snat`, `socket`, `state_match`, `string_matching`, `tcp_flags`.
 
 * `iptables`: Iptables type provider
     * Required binaries: `iptables-save`, `iptables`.
     * Default for `kernel` == `linux`.
-    * Supported features: `address_type`, `clusterip`, `connection_limiting`, `dnat`, `icmp_match`, `interface_match`, `iprange`, `ipsec_dir`, `ipsec_policy`, `ipset`, `iptables`, `isfragment`, `log_level`, `log_prefix`, `log_uid`, `mark`, `mask`, `mss`, `netmap`, `owner`, `pkttype`, `rate_limiting`, `recent_limiting`, `reject_type`, `snat`, `socket`, `state_match`, `tcp_flags`.
+    * Supported features: `address_type`, `clusterip`, `connection_limiting`, `dnat`, `icmp_match`, `interface_match`, `iprange`, `ipsec_dir`, `ipsec_policy`, `ipset`, `iptables`, `isfragment`, `length`, `log_level`, `log_prefix`, `log_uid`, `mark`, `mask`, `mss`, `netmap`, `owner`, `pkttype`, `rate_limiting`, `recent_limiting`, `reject_type`, `snat`, `socket`, `state_match`, `string_matching`, `tcp_flags`.
 
 **Autorequires:**
 
@@ -455,6 +455,8 @@ If Puppet is managing the iptables or iptables-persistent packages, and the prov
 
 * `islastfrag`: The ability to match the last fragment of an ipv6 packet.
 
+* `length`: The ability to match the length of the layer-3 payload.
+
 * `log_level`: The ability to control the log level.
 
 * `log_prefix`: The ability to add prefixes to log messages.
@@ -482,6 +484,8 @@ If Puppet is managing the iptables or iptables-persistent packages, and the prov
 * `socket`: The ability to match open sockets.
 
 * `state_match`: The ability to match stateful firewall states.
+
+* `string_matching`: The ability to match a given string by using some pattern matching strategy.
 
 * `tcp_flags`: The ability to match on particular TCP flag settings.
 
@@ -589,6 +593,8 @@ If Puppet is managing the iptables or iptables-persistent packages, and the prov
   If you set both `accept` and `jump` parameters, you will get an error, because only one of the options should be set. Requires the `iptables` feature.
 
 * `kernel_timezone`: Use the kernel timezone instead of UTC to determine whether a packet meets the time regulations.
+
+* `length`: Set the value for matching the length of the layer-3 payload. Can be a single number or a range using '-' as a separator. Requires the `length` feature.
 
 * `limit`: Rate limiting value for matched packets. The format is: 'rate/[/second/|/minute|/hour|/day]'. Example values are: '50/sec', '40/min', '30/hour', '10/day'. Requires the  `rate_limiting` feature.
 
@@ -742,6 +748,14 @@ firewall { '101 blacklist strange traffic':
 * `stat_probability`: Set the probability from 0 to 1 for a packet to be randomly matched. It works only with `stat_mode => 'random'`.
 
 * `state`: Matches a packet based on its state in the firewall stateful inspection table. Valid values are: 'INVALID', 'ESTABLISHED', 'NEW', 'RELATED'. Requires the `state_match` feature.
+
+* `string`: Set the pattern for string matching. Requires the `string_matching` feature.
+
+* `string_algo`: Used in conjunction with `string`, select the pattern matching strategy. Valid values are: 'bm', 'kmp' (bm = Boyer-Moore, kmp = Knuth-Pratt-Morris). Requires the `string_matching` feature.
+
+* `string_from`: Used in conjunction with `string`, set the offset from which it starts looking for any matching. Requires the `string_matching` feature.
+
+* `string_to`: Used in conjunction with `string`, set the offset up to which should be scanned. Requires the `string_matching` feature.
 
 * `table`: Table to use. Valid values are: 'nat', 'mangle', 'filter', 'raw', 'rawpost'. By default the setting is 'filter'. Requires the `iptables` feature.
 

--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -30,6 +30,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   has_feature :ipsec_policy
   has_feature :mask
   has_feature :ipset
+  has_feature :length
 
   optional_commands({
     :ip6tables      => 'ip6tables',
@@ -89,6 +90,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :ishasmorefrags     => "-m frag --fragid 0 --fragmore",
     :islastfrag         => "-m frag --fragid 0 --fraglast",
     :jump               => "-j",
+    :length             => "-m length --length",
     :limit              => "-m limit --limit",
     :log_level          => "--log-level",
     :log_prefix         => "--log-prefix",
@@ -221,7 +223,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :physdev_out, :physdev_is_bridged, :proto, :ishasmorefrags, :islastfrag, :isfirstfrag, :src_range, :dst_range,
     :tcp_flags, :uid, :gid, :mac_source, :sport, :dport, :port, :src_type,
     :dst_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy, :state,
-    :ctstate, :icmp, :hop_limit, :limit, :burst, :recent, :rseconds, :reap,
+    :ctstate, :icmp, :hop_limit, :limit, :burst, :length, :recent, :rseconds, :reap,
     :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :jump, :clamp_mss_to_pmtu, :gateway, :todest,
     :tosource, :toports, :checksum_fill, :log_level, :log_prefix, :log_uid, :reject, :set_mss, :set_dscp, :set_dscp_class, :mss,
     :set_mark, :match_mark, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone]

--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -31,6 +31,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
   has_feature :mask
   has_feature :ipset
   has_feature :length
+  has_feature :string_matching
 
   optional_commands({
     :ip6tables      => 'ip6tables',
@@ -127,6 +128,10 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :stat_packet        => '--packet',
     :stat_probability   => '--probability',
     :state              => "-m state --state",
+    :string             => "-m string --string",
+    :string_algo        => "--algo",
+    :string_from        => "--from",
+    :string_to          => "--to",
     :table              => "-t",
     :tcp_flags          => "-m tcp --tcp-flags",
     :todest             => "--to-destination",
@@ -224,7 +229,8 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :tcp_flags, :uid, :gid, :mac_source, :sport, :dport, :port, :src_type,
     :dst_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy, :state,
     :ctstate, :icmp, :hop_limit, :limit, :burst, :length, :recent, :rseconds, :reap,
-    :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :jump, :clamp_mss_to_pmtu, :gateway, :todest,
+    :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :string, :string_algo,
+    :string_from, :string_to, :jump, :clamp_mss_to_pmtu, :gateway, :todest,
     :tosource, :toports, :checksum_fill, :log_level, :log_prefix, :log_uid, :reject, :set_mss, :set_dscp, :set_dscp_class, :mss,
     :set_mark, :match_mark, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone]
 

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -34,6 +34,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   has_feature :mask
   has_feature :ipset
   has_feature :clusterip
+  has_feature :length
 
   optional_commands({
     :iptables => 'iptables',
@@ -74,6 +75,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :isfragment            => "-f",
     :jump                  => "-j",
     :goto                  => "-g",
+    :length                => "-m length --length",
     :limit                 => "-m limit --limit",
     :log_level             => "--log-level",
     :log_prefix            => "--log-prefix",
@@ -255,7 +257,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :stat_mode, :stat_every, :stat_packet, :stat_probability,
     :src_range, :dst_range, :tcp_flags, :uid, :gid, :mac_source, :sport, :dport, :port,
     :src_type, :dst_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy,
-    :state, :ctstate, :icmp, :limit, :burst, :recent, :rseconds, :reap,
+    :state, :ctstate, :icmp, :limit, :burst, :length, :recent, :rseconds, :reap,
     :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :jump, :goto, :clusterip_new, :clusterip_hashmode,
     :clusterip_clustermac, :clusterip_total_nodes, :clusterip_local_node, :clusterip_hash_init,
     :clamp_mss_to_pmtu, :gateway, :set_mss, :set_dscp, :set_dscp_class, :todest, :tosource, :toports, :to, :checksum_fill, :random, :log_prefix,

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -35,6 +35,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
   has_feature :ipset
   has_feature :clusterip
   has_feature :length
+  has_feature :string_matching
 
   optional_commands({
     :iptables => 'iptables',
@@ -113,6 +114,10 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :stat_packet           => '--packet',
     :stat_probability      => '--probability',
     :state                 => "-m state --state",
+    :string                => "-m string --string",
+    :string_algo           => "--algo",
+    :string_from           => "--from",
+    :string_to             => "--to",
     :table                 => "-t",
     :tcp_flags             => "-m tcp --tcp-flags",
     :todest                => "--to-destination",
@@ -258,7 +263,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :src_range, :dst_range, :tcp_flags, :uid, :gid, :mac_source, :sport, :dport, :port,
     :src_type, :dst_type, :socket, :pkttype, :name, :ipsec_dir, :ipsec_policy,
     :state, :ctstate, :icmp, :limit, :burst, :length, :recent, :rseconds, :reap,
-    :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :jump, :goto, :clusterip_new, :clusterip_hashmode,
+    :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :string, :string_algo,
+    :string_from, :string_to, :jump, :goto, :clusterip_new, :clusterip_hashmode,
     :clusterip_clustermac, :clusterip_total_nodes, :clusterip_local_node, :clusterip_hash_init,
     :clamp_mss_to_pmtu, :gateway, :set_mss, :set_dscp, :set_dscp_class, :todest, :tosource, :toports, :to, :checksum_fill, :random, :log_prefix,
     :log_level, :log_uid, :reject, :set_mark, :match_mark, :mss, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop,

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -495,6 +495,9 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
         elem.gsub(/:/,'-')
       end
     end
+    if hash[:length]
+      hash[:length].gsub!(/:/,'-')
+    end
 
     # Invert any rules that are prefixed with a '!'
     [

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -60,6 +60,7 @@ Puppet::Type.newtype(:firewall) do
   feature :ipset, "Match against specified ipset list"
   feature :clusterip, "Configure a simple cluster of nodes that share a certain IP and MAC address without an explicit load balancer in front of them."
   feature :length, "Match the length of layer-3 payload"
+  feature :string_matching, "String matching features"
 
   # provider specific features
   feature :iptables, "The provider provides iptables features."
@@ -1414,6 +1415,37 @@ Puppet::Type.newtype(:firewall) do
       end
       value
     end
+  end
+
+  newproperty(:string, :required_features => :string_matching) do
+    desc <<-EOS
+      String matching feature. Matches the packet against the pattern
+      given as an argument.
+    EOS
+
+    munge do |value|
+       value = "'" + value + "'"
+    end
+  end
+
+  newproperty(:string_algo, :required_features => :string_matching) do
+    desc <<-EOS
+      String matching feature, pattern matching strategy.
+    EOS
+
+    newvalues(:bm, :kmp)
+  end
+
+  newproperty(:string_from, :required_features => :string_matching) do
+    desc <<-EOS
+      String matching feature, offset from which we start looking for any matching.
+    EOS
+  end
+
+  newproperty(:string_to, :required_features => :string_matching) do
+    desc <<-EOS
+      String matching feature, offset  up  to which we should scan.
+    EOS
   end
 
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1393,22 +1393,24 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     munge do |value|
-      match = value.to_s.match("([0-9]+)(-)?([0-9]+)?")
-      low   = match[1].to_int
-      high  = match[3].to_int
-
-      if low.nil? or (low and match[2] and high.nil?)
+      match = value.to_s.match("^([0-9]+)(-)?([0-9]+)?$")
+      if match.nil?
         raise ArgumentError, "Length value must either be an integer or a range"
       end
 
-      if (low < 0 or low > 65535)
-        or (high and (high < 0 or high > 65535 or high < low))
+      low = match[1].to_i
+      if !match[3].nil?
+        high = match[3].to_i
+      end
+
+      if (low < 0 or low > 65535) or \
+        (!high.nil? and (high < 0 or high > 65535 or high < low))
         raise ArgumentError, "Length values must be between 0 and 65535"
       end
 
-      value = low
-      if high
-        value = value + ":#{high}"
+      value = low.to_s
+      if !high.nil?
+        value << ":" << high.to_s
       end
       value
     end

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1444,7 +1444,7 @@ Puppet::Type.newtype(:firewall) do
 
   newproperty(:string_to, :required_features => :string_matching) do
     desc <<-EOS
-      String matching feature, offset  up  to which we should scan.
+      String matching feature, offset up to which we should scan.
     EOS
   end
 

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -590,6 +590,43 @@ ARGS_TO_HASH = {
       :chain             => 'foo-filter',
     },
   },
+  'length_1' => {
+    :line   => '-A INPUT -m length --length 42000',
+    :table  => 'filter',
+    :params => {
+      :length => '42000',
+    },
+  },
+  'length_2' => {
+    :line   => '-A INPUT -m length --length 1492:65535',
+    :table  => 'filter',
+    :params => {
+      :length => '1492-65535',
+    },
+  },
+  'string_matching_1' => {
+    :line   => '-A INPUT -m string --string "GET /index.html"',
+    :table  => 'filter',
+    :params => {
+      :string => 'GET /index.html',
+    },
+  },
+  'string_matching_2' => {
+    :line   => '-A INPUT -m string --string "GET /index.html" --algo bm',
+    :table  => 'filter',
+    :params => {
+      :string      => 'GET /index.html',
+      :string_algo => 'bm',
+    },
+  },
+  'string_matching_3' => {
+    :line   => '-A INPUT -m string --string "GET /index.html" --from 1',
+    :table  => 'filter',
+    :params => {
+      :string      => 'GET /index.html',
+      :string_from => '1',
+    },
+  },
 }
 
 # This hash is for testing converting a hash to an argument line.
@@ -1125,5 +1162,48 @@ HASH_TO_ARGS = {
       :set_dscp_class    => 'ef',
     },
     :args => ["-t", :mangle, "-p", :tcp, "-m", "multiport", '--ports', '997', "-m", "comment", "--comment", "068 set dscp class to EF", "-j", "DSCP", "--set-dscp-class", "ef"],
+  },
+  'length_1' => {
+    :params => {
+      :name   => '000 length',
+      :table  => 'filter',
+      :length => '42000',
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", "000 length", "-m", "length", "--length", "42000"],
+  },
+  'length_2' => {
+    :params => {
+      :name   => '000 length',
+      :table  => 'filter',
+      :length => '1492-65535',
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", "000 length", "-m", "length", "--length", "1492:65535"],
+  },
+  'string_matching_1' => {
+    :params => {
+      :name   => '000 string_matching',
+      :table  => 'filter',
+      :string => 'GET /index.html',
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", "000 string_matching", "-m", "string", "--string", "'GET /index.html'"],
+  },
+  'string_matching_2' => {
+    :params => {
+      :name        => '000 string_matching',
+      :table       => 'filter',
+      :string      => 'GET /index.html',
+      :string_algo => 'bm',
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", "000 string_matching", "-m", "string", "--string", "'GET /index.html'", "--algo", :bm],
+  },
+  'string_matching_3' => {
+    :params => {
+      :name        => '000 string_matching',
+      :table       => 'filter',
+      :string      => 'GET /index.html',
+      :string_from => '1',
+      :string_to   => '65535',
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", "000 string_matching", "-m", "string", "--string", "'GET /index.html'", "--from", "1", "--to", "65535"],
   },
 }


### PR DESCRIPTION
We are using puppetlabs/puppetlabs-firewall in our puppet deployment, however we needed the module to handle the length and string iptables extensions. This pull request contains changes we had to apply.