### PR TITLE
(QENG-3973) Adding ubuntu-1604 nodeset

### DIFF
--- a/spec/acceptance/nodesets/new/pe/ubuntu-1604-32ma-32da-32da.yml
+++ b/spec/acceptance/nodesets/new/pe/ubuntu-1604-32ma-32da-32da.yml
@@ -1,0 +1,32 @@
+---
+HOSTS:
+  ubuntu-1604-i386-dashboard:
+    roles:
+    - dashboard
+    - agent
+    platform: ubuntu-16.04-i386
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-i386
+    hypervisor: vcloud
+  ubuntu-1604-i386-database:
+    roles:
+    - database
+    - agent
+    platform: ubuntu-16.04-i386
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1602-i386
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/ubuntu-1604-32mda.yml
+++ b/spec/acceptance/nodesets/new/pe/ubuntu-1604-32mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  ubuntu-1604-agent:
+    roles:
+    - agent
+    - default
+    platform: ubuntu-16.04-i386
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-i386
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/ubuntu-1604-64ma-64da-64da.yml
+++ b/spec/acceptance/nodesets/new/pe/ubuntu-1604-64ma-64da-64da.yml
@@ -1,0 +1,32 @@
+---
+HOSTS:
+  ubuntu-1604-amd64-dashboard:
+    roles:
+    - dashboard
+    - agent
+    platform: ubuntu-16.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+    hypervisor: vcloud
+  ubuntu-1604-amd64-database:
+    roles:
+    - database
+    - agent
+    platform: ubuntu-16.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600

--- a/spec/acceptance/nodesets/new/pe/ubuntu-1604-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/ubuntu-1604-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  ubuntu-1604-agent:
+    roles:
+    - agent
+    - default
+    platform: ubuntu-16.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1604-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600


### PR DESCRIPTION
Adding these special to this repo due to the ssh timeout used by firewall. Other modules use the qe-ci-module-helper repo for nodesets.