### PR TITLE
(MODULES-3572) Ip6tables service is not managed in the redhat family.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,7 +69,7 @@ Therefore, the run order is:
 
 The rules in the `pre` and `post` classes are fairly general. These two classes ensure that you retain connectivity and that you drop unmatched packets appropriately. The rules you define in your manifests are likely specific to the applications you run.
 
-1.) Add the `pre` class to my_fw/manifests/pre.pp. Your pre.pp file should contain any default rules to be applied first. The rules in this class should be added in the order you want them to run.2. 
+1.) Add the `pre` class to my_fw/manifests/pre.pp. Your pre.pp file should contain any default rules to be applied first. The rules in this class should be added in the order you want them to run.2.
   ~~~puppet
   class my_fw::pre {
     Firewall {
@@ -145,7 +145,7 @@ Rules are persisted automatically between reboots, although there are known issu
     purge => true,
   }
   ~~~
-  
+
   **Note** - If there are unmanaged rules in unmanaged chains, it will take two Puppet runs before the firewall chain is purged. This is different than the `purge` parameter available in `firewallchain`.
 
 2.)  Use the following code to set up the default parameters for all of the firewall rules you will establish later. These defaults will ensure that the `pre` and `post` classes are run in the correct order to avoid locking you out of your box during the first Puppet run.
@@ -387,19 +387,23 @@ Parameter that controls the state of the iptables service on your system, allowi
 
 `ensure` can either be 'running' or 'stopped'. Defaults to 'running'.
 
-#### package
-
-Specify the platform-specific package(s) to install. Defaults defined in `firewall::params`.
-
 #### pkg_ensure
 
 Parameter that controls the state of the iptables package on your system, allowing you to update it if you wish.
 
 `ensure` can either be 'present' or 'latest'. Defaults to 'present'.
 
-#### service
+#### service_name
 
-Specify the platform-specific service(s) to start or stop. Defaults defined in `firewall::params`.
+Specify the name of the IPv4 iptables service. Defaults defined in `firewall::params`.
+
+#### service_name_v6
+
+Specify the name of the IPv6 ip6tables service. Defaults defined in `firewall::params`.
+
+#### package_name
+
+Specify the platform-specific package(s) to install. Defaults defined in `firewall::params`.
 
 ###Type: firewall
 
@@ -877,7 +881,7 @@ As Puppet Enterprise itself does not yet support Debian 8, use of this module wi
 system should be regarded as experimental.
 
 ### Known Issues
- 
+
 #### MCollective causes PE to reverse firewall rule order
 
 Firewall rules appear in reverse order if you use MCollective to run Puppet in Puppet Enterprise 2016.1, 2015.3, 2015.2, or 3.8.x.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,10 +12,11 @@
 #   Default: running
 #
 class firewall (
-  $ensure       = running,
-  $pkg_ensure   = present,
-  $service_name = $::firewall::params::service_name,
-  $package_name = $::firewall::params::package_name,
+  $ensure          = running,
+  $pkg_ensure      = present,
+  $service_name    = $::firewall::params::service_name,
+  $service_name_v6 = $::firewall::params::service_name_v6,
+  $package_name    = $::firewall::params::package_name,
 ) inherits ::firewall::params {
   case $ensure {
     /^(running|stopped)$/: {
@@ -29,10 +30,11 @@ class firewall (
   case $::kernel {
     'Linux': {
       class { "${title}::linux":
-        ensure       => $ensure,
-        pkg_ensure   => $pkg_ensure,
-        service_name => $service_name,
-        package_name => $package_name,
+        ensure          => $ensure,
+        pkg_ensure      => $pkg_ensure,
+        service_name    => $service_name,
+        service_name_v6 => $service_name_v6,
+        package_name    => $package_name,
       }
     }
     'FreeBSD': {

--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -12,10 +12,11 @@
 #   Default: running
 #
 class firewall::linux (
-  $ensure       = running,
-  $pkg_ensure   = present,
-  $service_name = $::firewall::params::service_name,
-  $package_name = $::firewall::params::package_name,
+  $ensure          = running,
+  $pkg_ensure      = present,
+  $service_name    = $::firewall::params::service_name,
+  $service_name_v6 = $::firewall::params::service_name_v6,
+  $package_name    = $::firewall::params::package_name,
 ) inherits ::firewall::params {
   $enable = $ensure ? {
     running => true,
@@ -31,11 +32,12 @@ class firewall::linux (
     'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer',
     'VirtuozzoLinux': {
       class { "${title}::redhat":
-        ensure       => $ensure,
-        enable       => $enable,
-        package_name => $package_name,
-        service_name => $service_name,
-        require      => Package['iptables'],
+        ensure          => $ensure,
+        enable          => $enable,
+        package_name    => $package_name,
+        service_name    => $service_name,
+        service_name_v6 => $service_name_v6,
+        require         => Package['iptables'],
       }
     }
     'Debian', 'Ubuntu': {

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -21,10 +21,6 @@ class firewall::linux::redhat (
   $package_ensure  = $::firewall::params::package_ensure,
 ) inherits ::firewall::params {
 
-  # there is only one service per address family on RedHat
-  validate_string($service_name)
-  validate_string($service_name_v6)
-
   # RHEL 7 / CentOS 7 and later and Fedora 15 and later require the iptables-services
   # package, which provides the /usr/libexec/iptables/iptables.init used by
   # lib/puppet/util/firewall.rb.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,9 +2,10 @@ class firewall::params {
   $package_ensure = 'present'
   case $::osfamily {
     'RedHat': {
+      $service_name = 'iptables'
+      $service_name_v6 = 'ip6tables'
       case $::operatingsystem {
         'Amazon': {
-          $service_name = 'iptables'
           $package_name = undef
         }
         'Fedora': {
@@ -13,7 +14,6 @@ class firewall::params {
           } else {
             $package_name = undef
           }
-          $service_name = 'iptables'
         }
         default: {
           if versioncmp($::operatingsystemrelease, '7.0') >= 0 {
@@ -21,11 +21,11 @@ class firewall::params {
           } else {
             $package_name = 'iptables-ipv6'
           }
-          $service_name = 'iptables'
         }
       }
     }
     'Debian': {
+      $service_name_v6 = undef
       case $::operatingsystem {
         'Debian': {
           if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
@@ -55,9 +55,11 @@ class firewall::params {
     }
     'Gentoo': {
       $service_name = ['iptables','ip6tables']
+      $service_name_v6 = undef
       $package_name = 'net-firewall/iptables'
     }
     default: {
+      $service_name_v6 = undef
       case $::operatingsystem {
         'Archlinux': {
           $service_name = ['iptables','ip6tables']

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -53,6 +53,35 @@ describe 'firewall::linux::redhat', :type => :class do
           :selinux                => false,
         }}
 
+        it { should contain_service('iptables').with(
+          :ensure   => 'running',
+          :enable   => 'true'
+        )}
+        it { should contain_service('ip6tables').with(
+          :ensure   => 'running',
+          :enable   => 'true'
+        )}
+
+        context 'ensure => stopped' do
+          let(:params) {{ :ensure => 'stopped' }}
+          it { should contain_service('iptables').with(
+            :ensure   => 'stopped'
+          )}
+          it { should contain_service('ip6tables').with(
+            :ensure   => 'stopped'
+          )}
+        end
+
+        context 'enable => false' do
+          let(:params) {{ :enable => 'false' }}
+          it { should contain_service('iptables').with(
+            :enable   => 'false'
+          )}
+          it { should contain_service('ip6tables').with(
+            :enable   => 'false'
+          )}
+        end
+
         it { should contain_service('firewalld').with(
           :ensure => 'stopped',
           :enable => false,


### PR DESCRIPTION
For the redhat OS family the service for managing ip6tables is called
ip6tables. This service is currently not managed with this module.
This commit fixes this issue by introducing an additional parameter
$service_name_v6 for the ipv6 version of the service.
