### PR TITLE
Fixing issue with double quotes being removed when part of the comment

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -613,7 +613,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
 
   def delete_args
     # Split into arguments
-    line = properties[:line].gsub(/^\-A /, '-D ').split(/\s(?=(?:[^"]|"[^"]*")*$)/).map{|v| v.gsub(/"/, '')}
+    line = properties[:line].gsub(/^\-A /, '-D ').split(/\s(?=(?:[^"]|"[^"]*")*$)/).map{|v| v.gsub(/^"/, '').gsub(/"$/, '')}
     line.unshift("-t", properties[:table])
   end
 


### PR DESCRIPTION
If there are double quotes in the comment, the adding of the rule would work fine, but when it came to remove the rule, the double quotes were removed, and the rule was never removed from the system.

This fix will make sure that it only removes the quotes from the beginning and end of the string.
