### PR TITLE
Add --wait to iptables commands

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -628,6 +628,14 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     resource_map = self.class.instance_variable_get('@resource_map')
     resource_map = munge_resource_map_from_resource(resource_map, resource)
 
+    # Always attempt to wait for a lock for iptables to prevent failures when
+    # puppet is running at the same time something else is managing the rules
+    # note: --wait wasn't added untip iptables version 1.4.20
+    iptables_version = Facter.value('iptables_version')
+    if (iptables_version && Puppet::Util::Package.versioncmp(iptables_version, '1.4.20') >= 0)
+      args << ['--wait']
+    end
+
     resource_list.each do |res|
       resource_value = nil
       if (resource[res]) then


### PR DESCRIPTION
This change adds the --wait flag to the insert/update/delete iptables
actions to prevent failures from occuring when iptables is running
outside of puppet. Previously if a script or a user is running iptables
commands while puppet is running, there may be failures in the firewall
provider if iptables cannot get a lock. By default, iptables will just
fail with an error so using --wait will make it wait until a lock can be
established.
