### PR TITLE
iptables_version fact doesn't return the version

### DIFF
--- a/lib/facter/iptables_version.rb
+++ b/lib/facter/iptables_version.rb
@@ -1,5 +1,5 @@
 Facter.add(:iptables_version) do
-  confine :kernel => :linux
+  confine :kernel => :Linux
   setcode do
     version = Facter::Util::Resolution.exec('iptables --version')
     if version


### PR DESCRIPTION
When running 'facter iptables_version' it doesn't return a value. The bug seems to in the confine not matching the right kernel value.
