### PR TITLE
ip6tables_version fact doesn't return the version

### DIFF
--- a/lib/facter/ip6tables_version.rb
+++ b/lib/facter/ip6tables_version.rb
@@ -1,5 +1,5 @@
 Facter.add(:ip6tables_version) do
-  confine :kernel => :linux
+  confine :kernel => :Linux
   setcode do
     version = Facter::Util::Resolution.exec('ip6tables --version')
     if version


### PR DESCRIPTION
When running the 'facter ip6tables_version' it returns a empty string. The problem is in the confine :kernel => linux line. Adjusted this to capital L.
