### PR TITLE
(maint) Add node yaml file for oracle5

### DIFF
--- a/spec/acceptance/nodesets/new/pe/oracle-5-64mda.yml
+++ b/spec/acceptance/nodesets/new/pe/oracle-5-64mda.yml
@@ -1,0 +1,27 @@
+---
+HOSTS:
+  oracle-5-x86_64-agent:
+    roles:
+    - agent
+    - default
+    platform: el-5-x86_64
+    template: oracle-5-x86_64
+    hypervisor: vcloud
+  redhat-7-x86_64-master:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  ssh:
+    timeout: 600


### PR DESCRIPTION
Prior to this commit the firewall module did not have a node file
for oracle5 so it was failing in CI. In order to fix this, add the
appropriate config file so tests can be run on oracle5.