### PR TITLE
Re-add RHEL7 SELinux support for puppet3

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -64,4 +64,23 @@ class firewall::linux::redhat (
     group  => 'root',
     mode   => '0600',
   }
+
+  # Before puppet 4, the autobefore on the firewall type does not work - therefore
+  # we need to keep this workaround here
+  if versioncmp($::puppetversion, '4.0') <= 0 {
+    File["/etc/sysconfig/${service_name}"] -> Service[$service_name]
+
+    # Redhat 7 selinux user context for /etc/sysconfig/iptables is set to unconfined_u
+    case $::selinux {
+      #lint:ignore:quoted_booleans
+      'true',true: {
+        case $::operatingsystemrelease {
+          /^(6|7)\..*/: { File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u' } }
+          default:      { File["/etc/sysconfig/${service_name}"] { seluser => 'system_u' } }
+        }
+      }
+      default:     {}
+      #lint:endignore
+    }
+  }
 }

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -35,6 +35,7 @@ describe 'firewall::linux::redhat', :type => :class do
           :operatingsystemrelease => osrel,
           :osfamily               => 'RedHat',
           :selinux                => false,
+          :puppetversion          => Puppet.version,
         }}
 
         it { should_not contain_service('firewalld') }
@@ -51,6 +52,7 @@ describe 'firewall::linux::redhat', :type => :class do
           :operatingsystemrelease => osrel,
           :osfamily               => 'RedHat',
           :selinux                => false,
+          :puppetversion          => Puppet.version,
         }}
 
         it { should contain_service('firewalld').with(

--- a/spec/unit/classes/firewall_linux_spec.rb
+++ b/spec/unit/classes/firewall_linux_spec.rb
@@ -13,6 +13,7 @@ describe 'firewall::linux', :type => :class do
               :operatingsystemrelease => osrel,
               :osfamily               => 'RedHat',
               :selinux                => false,
+              :puppetversion          => Puppet.version,
             }}
             it { should contain_class('firewall::linux::redhat').with_require('Package[iptables]') }
             it { should contain_package('iptables').with_ensure('present') }
@@ -33,6 +34,7 @@ describe 'firewall::linux', :type => :class do
             :operatingsystemrelease => osrel,
             :osfamily               => 'Debian',
             :selinux                => false,
+            :puppetversion          => Puppet.version,
           }}
 
           it { should contain_class('firewall::linux::debian').with_require('Package[iptables]') }


### PR DESCRIPTION
Since the autobefore fix on the firewall type is not available for puppet 3,
this re-adds the RHEL7 workaround if we're running on puppet 3.

Closes #659 