### PR TITLE
(MODULES-4200) Add simple sanity check for the rule to hash parser

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -438,10 +438,16 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     values.slice!('-A')
     keys << :chain
 
+    valrev = values.scan(/("([^"\\]|\\.)*"|\S+)/).transpose[0].reverse
+
+    if keys.length != valrev.length then
+      raise "Parser error: keys (#{keys.length}) and values (#{valrev.length}) count mismatch on line: #{line}"
+    end
+
     # Here we generate the main hash by scanning arguments off the values
     # string, handling any quoted characters present in the value, and then
     # zipping the values with the array of keys.
-    keys.zip(values.scan(/("([^"\\]|\\.)*"|\S+)/).transpose[0].reverse) do |f, v|
+    keys.zip(valrev) do |f, v|
       if v =~ /^".*"$/ then
         hash[f] = v.sub(/^"(.*)"$/, '\1').gsub(/\\(\\|'|")/, '\1')
       else

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -435,8 +435,10 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     end
 
     # Manually remove chain
-    values.slice!('-A')
-    keys << :chain
+    if values =~ /(\s|^)-A\s/
+      values = values.sub(/(\s|^)-A\s/, '\1')
+      keys << :chain
+    end
 
     valrev = values.scan(/("([^"\\]|\\.)*"|\S+)/).transpose[0].reverse
 

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -440,6 +440,12 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
       keys << :chain
     end
 
+    # Manually remove table (used in some tests)
+    if values =~ /^-t\s/
+      values = values.sub(/^-t\s/, '')
+      keys << :table
+    end
+
     valrev = values.scan(/("([^"\\]|\\.)*"|\S+)/).transpose[0].reverse
 
     if keys.length != valrev.length then

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -663,6 +663,12 @@ ARGS_TO_HASH = {
       :proto        => "tcp",
     },
   },
+  'parser_sanity_check' => {
+    :line   => '-A INPUT -s 1.2.3.4/32 -p tcp -m tcp --dport 80 --tcp-flags FIN,SYN,RST,ACK SYN -m comment --comment "004 parser sanity check" -j ACCEPT',
+    :table  => 'filter',
+    :raise_error => true,
+    :params => {},
+  },
 }
 
 # This hash is for testing converting a hash to an argument line.

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -215,6 +215,13 @@ describe 'iptables provider' do
     ARGS_TO_HASH.each do |test_name,data|
       describe "for test data '#{test_name}'" do
         let(:resource) { provider.rule_to_hash(data[:line], data[:table], 0) }
+        # If this option is enabled, make sure the error was raised
+        if data[:raise_error] then
+          it "the input rules should raise an error by rules_to_hash" do
+            expect{ resource }.to raise_error
+          end
+        end
+
         # If this option is enabled, make sure the parameters exactly match
         if data[:compare_all] then
           it "the parameter hash keys should be the same as returned by rules_to_hash" do


### PR DESCRIPTION
We have manual and puppet controlled chains, and someone manually added rule like this:

`-A INPUT -s 1.2.3.4/32 -p tcp -m -tcp --dport 80 --tcp-flags FIN,SYN,RST,ACK SYN -m comment --comment "some comment" -j ACCEPT`

and puppet started throwing errors like:

`Could not evaluate: Invalid address from IPAddr.new: 80`

After some digging I've found that the rule is not properly parsed because of the `--dport 80` between `-m tcp` and `--tcp-flags`. Similar issues can be expected with other combined arguments from the resource_map. It's hard to cover all those cases so I've added simple sanity check for the parser.

https://tickets.puppetlabs.com/browse/MODULES-4200