### PR TITLE
MODULES-1748 Handle negative physdev-is-bridged

### DIFF
--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -661,6 +661,13 @@ ARGS_TO_HASH = {
       :destination  => "4.3.2.1/32",
       :jump         => "NFQUEUE",
       :proto        => "tcp",
+  },
+  'negative_physdev_is_bridged_with_jump' => {
+    :line => '-A FORWARD -m physdev ! --physdev-is-bridged -j REJECT --reject-with icmp-host-prohibited',
+    :params => {
+      :physdev_is_bridged => '!',
+      :action             => 'reject',
+      :chain              => 'true',
     },
   },
 }


### PR DESCRIPTION
With an iptables line like this:

-A FORWARD -m physdev ! --physdev-is-bridged -j REJECT \
--reject-with icmp-host-prohibited

You'd get:

Parser error: physdev_is_bridged was meant to be a
boolean but received value: REJECT.

* The pre-cludge regex's were being over greedy and taking -j as
part of the quoted value.
* I allowed @known_booleans to also be "!" - perhaps this could
be done better tho.
* I also added physdev_is_bridged to the rules that can be prefixed
with a "!".

Conflicts:
	spec/fixtures/iptables/conversion_hash.rb