### PR TITLE
Add RHEL7 SELinux support for new service_name_v6 param, subsequently fix puppet lint error

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -72,6 +72,13 @@ class firewall::linux::redhat (
     mode   => '0600',
   }
 
+  file { "/etc/sysconfig/${service_name_v6}":
+    ensure => present,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0600',
+  }
+
   # Before puppet 4, the autobefore on the firewall type does not work - therefore
   # we need to keep this workaround here
   if versioncmp($::puppetversion, '4.0') <= 0 {
@@ -85,23 +92,28 @@ class firewall::linux::redhat (
         case $::operatingsystemrelease {
           /^7\..*/: {
             case $::operatingsystem {
-              'CentOS': { File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' } }
-              default : { File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u', seltype => 'etc_t' } }
+              'CentOS': {
+                File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' }
+                File["/etc/sysconfig/${service_name_v6}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' }
+              }
+              default : {
+                File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u', seltype => 'etc_t' }
+                File["/etc/sysconfig/${service_name_v6}"] { seluser => 'unconfined_u', seltype => 'etc_t' }
+              }
             }
           }
-          /^6\..*/:     { File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' } }
-          default:      { File["/etc/sysconfig/${service_name}"] { seluser => 'system_u', seltype => 'system_conf_t' } }
+          /^6\..*/:     {
+            File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' }
+            File["/etc/sysconfig/${service_name_v6}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' }
+          }
+          default:      {
+            File["/etc/sysconfig/${service_name}"] { seluser => 'system_u', seltype => 'system_conf_t' }
+            File["/etc/sysconfig/${service_name_v6}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' }
+          }
         }
       }
       default:     {}
       #lint:endignore
     }
-  }
-  file { "/etc/sysconfig/${service_name_v6}":
-    ensure  => present,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0600',
-    seluser => $seluser,
   }
 }


### PR DESCRIPTION
This originally started as a fix for a puppet lint issue in CI, where the $seluser variable had been removed from the firewall::linux::redhat class as seluser property for the File["/etc/sysconfig/${service_name}"] resource is now set in a case statement. 

When a separate PR was merged adding the 'service_name_v6' param, it still used the $seluser variable to set the seluser property of the File["/etc/sysconfig/${service_name_v6}"] resource.

When both these PR's were merged they then caused a puppet lint error in CI.