### PR TITLE
Add gid lookup

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -845,6 +845,45 @@ Puppet::Type.newtype(:firewall) do
       only, as iptables does not accept multiple gid in a single
       statement.
     EOS
+    def insync?(is)
+      require 'etc'
+
+      # The following code allow us to take into consideration unix mappings
+      # between string group names and GIDs (integers). We also need to ignore
+      # spaces as they are irrelevant with respect to rule sync.
+
+      # Remove whitespace
+      is = is.gsub(/\s+/,'')
+      should = @should.first.to_s.gsub(/\s+/,'')
+
+      # Keep track of negation, but remove the '!'
+      is_negate = ''
+      should_negate = ''
+      if is.start_with?('!')
+        is = is.gsub(/^!/,'')
+        is_negate = '!'
+      end
+      if should.start_with?('!')
+        should = should.gsub(/^!/,'')
+        should_negate = '!'
+      end
+
+      # If 'should' contains anything other than digits,
+      # we assume that we have to do a lookup to convert
+      # to UID
+      unless should[/[0-9]+/] == should
+        should = Etc.getgrnam(should).gid
+      end
+
+      # If 'is' contains anything other than digits,
+      # we assume that we have to do a lookup to convert
+      # to UID
+      unless is[/[0-9]+/] == is
+        is = Etc.getgrnam(is).gid
+      end
+
+      return "#{is_negate}#{is}" == "#{should_negate}#{should}"
+    end
   end
 
   # match mark

--- a/spec/acceptance/firewall_gid_spec.rb
+++ b/spec/acceptance/firewall_gid_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper_acceptance'
+
+describe 'firewall gid' do
+  before :all do
+    iptables_flush_all_tables
+    ip6tables_flush_all_tables
+  end
+
+  describe "gid tests" do
+    context 'gid set to root' do
+      it 'applies' do
+        pp = <<-EOS
+          class { '::firewall': }
+          firewall { '801 - test':
+            chain => 'OUTPUT',
+            action => accept,
+            gid => 'root',
+            proto => 'all',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => do_catch_changes)
+      end
+
+      it 'should contain the rule' do
+         shell('iptables-save') do |r|
+           expect(r.stdout).to match(/-A OUTPUT -m owner --gid-owner (0|root) -m comment --comment "801 - test" -j ACCEPT/)
+         end
+      end
+    end
+
+    context 'gid set to !root' do
+      it 'applies' do
+        pp = <<-EOS
+          class { '::firewall': }
+          firewall { '802 - test':
+            chain => 'OUTPUT',
+            action => accept,
+            gid => '!root',
+            proto => 'all',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => do_catch_changes)
+      end
+
+      it 'should contain the rule' do
+         shell('iptables-save') do |r|
+           expect(r.stdout).to match(/-A OUTPUT -m owner ! --gid-owner (0|root) -m comment --comment "802 - test" -j ACCEPT/)
+         end
+      end
+    end
+
+    context 'gid set to 0' do
+      it 'applies' do
+        pp = <<-EOS
+          class { '::firewall': }
+          firewall { '803 - test':
+            chain => 'OUTPUT',
+            action => accept,
+            gid => '0',
+            proto => 'all',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => do_catch_changes)
+      end
+
+      it 'should contain the rule' do
+         shell('iptables-save') do |r|
+           expect(r.stdout).to match(/-A OUTPUT -m owner --gid-owner (0|root) -m comment --comment "803 - test" -j ACCEPT/)
+         end
+      end
+    end
+
+    context 'gid set to !0' do
+      it 'applies' do
+        pp = <<-EOS
+          class { '::firewall': }
+          firewall { '804 - test':
+            chain => 'OUTPUT',
+            action => accept,
+            gid => '!0',
+            proto => 'all',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => do_catch_changes)
+      end
+
+      it 'should contain the rule' do
+         shell('iptables-save') do |r|
+           expect(r.stdout).to match(/-A OUTPUT -m owner ! --gid-owner (0|root) -m comment --comment "804 - test" -j ACCEPT/)
+         end
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
The "uid" parameter for the firewall type correctly deals with mapping between usernames and UIDs as required, however the same isn't true for GIDs, which leads to spurious changes on every puppet run. This PR adds a similar mapping to GIDs.