### PR TITLE
Add mark/mask format to match_mark

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -854,7 +854,7 @@ Puppet::Type.newtype(:firewall) do
       mark/mask or mark.  These will be converted to hex if they are not already.
     EOS
     munge do |value|
-      mark_regex = %r{\A((?:0x)?[0-9A-F]+)(/)?((?:0x)?[0-9A-F]+)?\z}i
+      mark_regex = %r{\A((?:0x)?[0-9A-F]+)(/((?:0x)?[0-9A-F]+))?\z}i
       match = value.to_s.match(mark_regex)
       if match.nil?
         raise ArgumentError, "Match MARK value must be integer or hex between 0 and 0xffffffff"
@@ -863,15 +863,19 @@ Puppet::Type.newtype(:firewall) do
 
       # Values that can't be converted to hex.
       # Or contain a trailing slash with no mask.
-      if mark.nil? or (mark and match[2] and match[3].nil?)
+      if mark.nil?
         raise ArgumentError, "Match MARK value must be integer or hex between 0 and 0xffffffff"
       end
 
-      # There should not be a mask on match_mark
-      unless match[3].nil?
-        raise ArgumentError, "iptables does not support masks on MARK match rules"
-      end
       value = mark
+
+      unless match[2].nil?
+        mask = @resource.to_hex32(match[3])
+        if mask.nil?
+          raise ArgumentError, "When provided, match MARK mask must be integer or hex between 0 and 0xffffffff"
+        end
+        value = value + "/" + mask
+      end
 
       value
     end

--- a/spec/acceptance/match_mark_spec.rb
+++ b/spec/acceptance/match_mark_spec.rb
@@ -30,6 +30,29 @@ describe 'firewall match marks' do
       end
     end
 
+    describe 'match_mark_mask' do
+      context '0x1/0xff' do
+        it 'applies' do
+          pp = <<-EOS
+            class { '::firewall': }
+            firewall { '504 match_mark w mask - test':
+              proto      => 'all',
+              match_mark => '0x1/0xff',
+              action     => reject,
+            }
+          EOS
+
+          apply_manifest(pp, :catch_failures => true)
+        end
+
+        it 'should contain the rule' do
+          shell('iptables-save') do |r|
+            expect(r.stdout).to match(/-A INPUT -m comment --comment "504 match_mark w mask - test" -m mark --mark 0x1\/0xff -j REJECT --reject-with icmp-port-unreachable/)
+          end
+        end
+      end
+    end
+
     describe 'match_mark_ip6' do
       context '0x1' do
         it 'applies' do
@@ -49,6 +72,30 @@ describe 'firewall match marks' do
         it 'should contain the rule' do
           shell('ip6tables-save') do |r|
             expect(r.stdout).to match(/-A INPUT -m comment --comment "503 match_mark ip6tables - test" -m mark --mark 0x1 -j REJECT --reject-with icmp6-port-unreachable/)
+          end
+        end
+      end
+    end
+
+    describe 'match_mark_ip6_mask' do
+      context '0x1/0xff' do
+        it 'applies' do
+          pp = <<-EOS
+            class { '::firewall': }
+            firewall { '504 match_mark w mask ip6tables - test':
+              proto      => 'all',
+              match_mark => '0x1/0xff',
+              action     => reject,
+              provider => 'ip6tables',
+            }
+          EOS
+
+          apply_manifest(pp, :catch_failures => true)
+        end
+
+        it 'should contain the rule' do
+          shell('ip6tables-save') do |r|
+            expect(r.stdout).to match(/-A INPUT -m comment --comment "504 match_mark w mask ip6tables - test" -m mark --mark 0x1\/0xff -j REJECT --reject-with icmp6-port-unreachable/)
           end
         end
       end

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -570,6 +570,17 @@ ARGS_TO_HASH = {
       :action          => 'reject',
     },
   },
+  'match_mark_mask' => {
+    :line => '-A INPUT -p tcp -m comment --comment "066 REJECT connlimit_above 10 with mask 32 and mark matches" -m mark --mark 0x1/0xff -m connlimit --connlimit-above 10 --connlimit-mask 32 -j REJECT --reject-with icmp-port-unreachable',
+    :table => 'filter',
+    :params => {
+      :proto           => 'tcp',
+      :connlimit_above => '10',
+      :connlimit_mask  => '32',
+      :match_mark      => '0x1/0xff',
+      :action          => 'reject',
+    },
+  },
   'clamp_mss_to_pmtu' => {
     :line => '-A INPUT -p tcp -m tcp --tcp-flags SYN,RST SYN -m comment --comment "067 change max segment size" -j TCPMSS --clamp-mss-to-pmtu',
     :table => 'filter',
@@ -1176,6 +1187,18 @@ HASH_TO_ARGS = {
       :action          => 'reject',
     },
     :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", "066 REJECT connlimit_above 10 with mask 32 and mark matches", "-j", "REJECT", "-m", "mark", "--mark", "0x1", "-m", "connlimit", "--connlimit-above", "10", "--connlimit-mask", "32"],
+  },
+  'match_mark_mask' => {
+    :params => {
+      :name            => '066 REJECT connlimit_above 10 with mask 32 and mark matches',
+      :table           => 'filter',
+      :proto           => 'tcp',
+      :connlimit_above => '10',
+      :connlimit_mask  => '32',
+      :match_mark      => '0x1/0xff',
+      :action          => 'reject',
+    },
+    :args => ["-t", :filter, "-p", :tcp, "-m", "comment", "--comment", "066 REJECT connlimit_above 10 with mask 32 and mark matches", "-j", "REJECT", "-m", "mark", "--mark", "0x1/0xff", "-m", "connlimit", "--connlimit-above", "10", "--connlimit-mask", "32"],
   },
   'clamp_mss_to_pmtu' => {
     :params => {


### PR DESCRIPTION
The current version of match_mark parses mark/mask, but does not
actually allow this format. Enable usage of the mask.