### PR TITLE
[MODULES-4234] Move physdev_is_in and physdev_is_out tests

### DIFF
--- a/spec/acceptance/firewall_bridging_spec.rb
+++ b/spec/acceptance/firewall_bridging_spec.rb
@@ -364,12 +364,10 @@ describe 'firewall bridging' do
              end
           end
         end
-      end
-    end
 
-    context 'physdev_is_in' do
-      it 'applies' do
-        pp = <<-EOS
+        context 'physdev_is_in' do
+          it 'applies' do
+            pp = <<-EOS
           class { '::firewall': }
           firewall { '708 - test':
             provider => 'ip6tables',
@@ -379,22 +377,22 @@ describe 'firewall bridging' do
             action => accept,
             physdev_is_in => true,
           }
-        EOS
+            EOS
 
-        apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => do_catch_changes)
-      end
+            apply_manifest(pp, :catch_failures => true)
+            apply_manifest(pp, :catch_changes => do_catch_changes)
+          end
 
-      it 'should contain the rule' do
-         shell('ip6tables-save') do |r|
-           expect(r.stdout).to match(/-A FORWARD -p tcp -m physdev\s+--physdev-is-in -m multiport --ports 708 -m comment --comment "708 - test" -j ACCEPT/)
-         end
-      end
-    end
+          it 'should contain the rule' do
+            shell('ip6tables-save') do |r|
+              expect(r.stdout).to match(/-A FORWARD -p tcp -m physdev\s+--physdev-is-in -m multiport --ports 708 -m comment --comment "708 - test" -j ACCEPT/)
+            end
+          end
+        end
 
-    context 'physdev_is_out' do
-      it 'applies' do
-        pp = <<-EOS
+        context 'physdev_is_out' do
+          it 'applies' do
+            pp = <<-EOS
           class { '::firewall': }
           firewall { '709 - test':
             provider => 'ip6tables',
@@ -404,16 +402,18 @@ describe 'firewall bridging' do
             action => accept,
             physdev_is_out => true,
           }
-        EOS
+            EOS
 
-        apply_manifest(pp, :catch_failures => true)
-        apply_manifest(pp, :catch_changes => do_catch_changes)
-      end
+            apply_manifest(pp, :catch_failures => true)
+            apply_manifest(pp, :catch_changes => do_catch_changes)
+          end
 
-      it 'should contain the rule' do
-         shell('ip6tables-save') do |r|
-           expect(r.stdout).to match(/-A FORWARD -p tcp -m physdev\s+--physdev-is-out -m multiport --ports 709 -m comment --comment "709 - test" -j ACCEPT/)
-         end
+          it 'should contain the rule' do
+            shell('ip6tables-save') do |r|
+              expect(r.stdout).to match(/-A FORWARD -p tcp -m physdev\s+--physdev-is-out -m multiport --ports 709 -m comment --comment "709 - test" -j ACCEPT/)
+            end
+          end
+        end
       end
-    end
+  end
 end


### PR DESCRIPTION
Move physdev_is_in and physdev_is_out tests to block with the rest of the 'ip6tables physdev tests' which do not run on EL5 or SLES 10 due to iptables version 1.3.5 is not suppored by the ip6tables provider on those platforms.

This is a result of PR #685 causing CI failures on Redhat 5 and Scientific 5.