### PR TITLE
MODULES-4279 use complete option for geoip

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -155,8 +155,8 @@ Puppet::Type.type(:firewall).provide :ip6tables, :parent => :iptables, :source =
     :week_days          => "--weekdays",
     :time_contiguous    => "--contiguous",
     :kernel_timezone    => "--kerneltz",
-    :src_cc             => "--src-cc",
-    :dst_cc             => "--dst-cc",
+    :src_cc             => "--source-country",
+    :dst_cc             => "--destination-country",
   }
 
   # These are known booleans that do not take a value, but we want to munge

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -148,8 +148,8 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     :clusterip_total_nodes => "--total-nodes",
     :clusterip_local_node  => "--local-node",
     :clusterip_hash_init   => "--hash-init",
-    :src_cc                => "--src-cc",
-    :dst_cc                => "--dst-cc",
+    :src_cc                => "--source-country",
+    :dst_cc                => "--destination-country",
   }
 
   # These are known booleans that do not take a value, but we want to munge


### PR DESCRIPTION
The geo rules will be generated over and over again if the matching options are not exactly the same.
So it has to be --source-country instead of --src-cc.
Without that, every puppet run will generate the geo rules new and dont purge the old ones.