### PR TITLE
allow ip6tables to be disabled

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
+  repositories:
+    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     "firewall": "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,11 +13,14 @@
 #
 class firewall (
   $ensure          = running,
+  $ensure_v6       = undef,
   $pkg_ensure      = present,
   $service_name    = $::firewall::params::service_name,
   $service_name_v6 = $::firewall::params::service_name_v6,
   $package_name    = $::firewall::params::package_name,
 ) inherits ::firewall::params {
+  $_ensure_v6 = pick($ensure_v6, $ensure)
+
   case $ensure {
     /^(running|stopped)$/: {
       # Do nothing.
@@ -27,10 +30,22 @@ class firewall (
     }
   }
 
+  if $ensure_v6 {
+    case $ensure_v6 {
+      /^(running|stopped)$/: {
+        # Do nothing.
+      }
+      default: {
+        fail("${title}: ensure_v6 value '${ensure_v6}' is not supported")
+      }
+    }
+  }
+
   case $::kernel {
     'Linux': {
       class { "${title}::linux":
         ensure          => $ensure,
+        ensure_v6       => $_ensure_v6,
         pkg_ensure      => $pkg_ensure,
         service_name    => $service_name,
         service_name_v6 => $service_name_v6,

--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -11,14 +11,27 @@
 #   service will be started on boot, and when `stopped` it will not.
 #   Default: running
 #
+# [*ensure_v6*]
+#   Ensure parameter passed onto Service[] resources. When `running` the
+#   service will be started on boot, and when `stopped` it will not.
+#   Default: running
+#
 class firewall::linux (
   $ensure          = running,
+  $ensure_v6       = undef,
   $pkg_ensure      = present,
   $service_name    = $::firewall::params::service_name,
   $service_name_v6 = $::firewall::params::service_name_v6,
   $package_name    = $::firewall::params::package_name,
 ) inherits ::firewall::params {
   $enable = $ensure ? {
+    running => true,
+    stopped => false,
+  }
+
+  $_ensure_v6 = pick($ensure_v6, $ensure)
+
+  $_enable_v6 = $_ensure_v6 ? {
     running => true,
     stopped => false,
   }
@@ -33,7 +46,9 @@ class firewall::linux (
     'VirtuozzoLinux': {
       class { "${title}::redhat":
         ensure          => $ensure,
+        ensure_v6       => $_ensure_v6,
         enable          => $enable,
+        enable_v6       => $_enable_v6,
         package_name    => $package_name,
         service_name    => $service_name,
         service_name_v6 => $service_name_v6,

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -59,9 +59,10 @@ class firewall::linux::redhat (
     or  ($::operatingsystem == 'Fedora' and versioncmp($::operatingsystemrelease, '15') >= 0)) {
     if $ensure == 'running' {
       exec { '/usr/bin/systemctl daemon-reload':
-        require => Package[$package_name],
-        before  => Service[$service_name, $service_name_v6],
-        unless  => "/usr/bin/systemctl is-active ${service_name} ${service_name_v6}",
+        require     => Package[$package_name],
+        before      => Service[$service_name, $service_name_v6],
+        subscribe   => Package[$package_name],
+        refreshonly => true,
       }
     }
   }

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -8,18 +8,31 @@
 #   Ensure parameter passed onto Service[] resources.
 #   Default: running
 #
+# [*ensure_v6*]
+#   Ensure parameter passed onto Service[] resources.
+#   Default: running
+#
 # [*enable*]
 #   Enable parameter passed onto Service[] resources.
 #   Default: true
 #
+# [*enable_v6*]
+#   Enable parameter passed onto Service[] resources.
+#   Default: true
+#
+#
 class firewall::linux::redhat (
   $ensure          = running,
+  $ensure_v6       = undef,
   $enable          = true,
+  $enable_v6       = undef,
   $service_name    = $::firewall::params::service_name,
   $service_name_v6 = $::firewall::params::service_name_v6,
   $package_name    = $::firewall::params::package_name,
   $package_ensure  = $::firewall::params::package_ensure,
 ) inherits ::firewall::params {
+  $_ensure_v6 = pick($ensure_v6, $ensure)
+  $_enable_v6 = pick($enable_v6, $enable)
 
   # RHEL 7 / CentOS 7 and later and Fedora 15 and later require the iptables-services
   # package, which provides the /usr/libexec/iptables/iptables.init used by
@@ -59,8 +72,8 @@ class firewall::linux::redhat (
     hasstatus => true,
   }
   service { $service_name_v6:
-    ensure    => $ensure,
-    enable    => $enable,
+    ensure    => $_ensure_v6,
+    enable    => $_enable_v6,
     hasstatus => true,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,6 @@
     }
   ],
   "dependencies": [
-
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.0 < 5.0.0"}
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -31,6 +31,7 @@ RSpec.configure do |c|
   c.before :suite do
     # Install module and dependencies
     hosts.each do |host|
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0] }
       # the ubuntu-14.04 docker image doesn't carry the iptables command
       apply_manifest_on host, 'package { "iptables": ensure => installed }' if fact('osfamily') == 'Debian'
     end

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -60,8 +60,8 @@ describe 'firewall::linux::redhat', :type => :class do
           :enable   => 'true'
         )}
         it { should contain_service('ip6tables').with(
-          :ensure   => 'running',
-          :enable   => 'true'
+          :ensure    => 'running',
+          :enable    => 'true'
         )}
 
         context 'ensure => stopped' do
@@ -69,8 +69,12 @@ describe 'firewall::linux::redhat', :type => :class do
           it { should contain_service('iptables').with(
             :ensure   => 'stopped'
           )}
+        end
+
+        context 'ensure_v6 => stopped' do
+          let(:params) {{ :ensure_v6 => 'stopped' }}
           it { should contain_service('ip6tables').with(
-            :ensure   => 'stopped'
+            :ensure  => 'stopped'
           )}
         end
 
@@ -79,8 +83,12 @@ describe 'firewall::linux::redhat', :type => :class do
           it { should contain_service('iptables').with(
             :enable   => 'false'
           )}
+        end
+
+        context 'enable_v6 => false' do
+          let(:params) {{ :enable_v6 => 'false' }}
           it { should contain_service('ip6tables').with(
-            :enable   => 'false'
+            :enable  => 'false'
           )}
         end
 


### PR DESCRIPTION
many hardened systems have IPv6 disabled, which
does not allow ip6tables to be running.  allow
ip6tables to be selectively disabled in these cases.

errors when IPv6 is disabled:

Error: Could not start Service[ip6tables]: Execution of '/usr/bin/systemctl start ip6tables' returned 1: Job for ip6tables.service failed because the control process exited with error code. See "systemctl status ip6tables.service" and "journalctl -xe" for details.
Error: /Stage[main]/Firewall::Linux::Redhat/Service[ip6tables]/ensure: change from stopped to running failed: Could not start Service[ip6tables]: Execution of '/usr/bin/systemctl start ip6tables' returned 1: Job for ip6tables.service failed because the control process exited with error code. See "systemctl status ip6tables.service" and "journalctl -xe" for details.

● ip6tables.service - IPv6 firewall with ip6tables
   Loaded: loaded (/usr/lib/systemd/system/ip6tables.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Fri 2017-04-07 01:36:45 UTC; 25min ago
  Process: 10257 ExecStart=/usr/libexec/iptables/ip6tables.init start (code=exited, status=1/FAILURE)
 Main PID: 10257 (code=exited, status=1/FAILURE)

Apr 07 01:36:45 el7-1.example.com systemd[1]: Starting IPv6 firewall with ip6tables...
Apr 07 01:36:45 el7-1.example.com ip6tables.init[10257]: ip6tables: Applying firewall rules: ip6tab...r'
Apr 07 01:36:45 el7-1.example.com ip6tables.init[10257]: Error occurred at line: 4
Apr 07 01:36:45 el7-1.example.com ip6tables.init[10257]: Try `ip6tables-restore -h' or 'ip6tables-r...n.
Apr 07 01:36:45 el7-1.example.com ip6tables.init[10257]: [FAILED]
Apr 07 01:36:45 el7-1.example.com systemd[1]: ip6tables.service: main process exited, code=exited,...URE
Apr 07 01:36:45 el7-1.example.com systemd[1]: Failed to start IPv6 firewall with ip6tables.
Apr 07 01:36:45 el7-1.example.com systemd[1]: Unit ip6tables.service entered failed state.
Apr 07 01:36:45 el7-1.example.com systemd[1]: ip6tables.service failed.
Hint: Some lines were ellipsized, use -l to show in full.