### PR TITLE
Change - Ensure that firewalld is stopped before iptables starts

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -30,7 +30,7 @@ class firewall::linux::redhat (
     service { 'firewalld':
       ensure => stopped,
       enable => false,
-      before => Package[$package_name],
+      before => [Package[$package_name], Service[$service_name]],
     }
   }
 

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -87,7 +87,7 @@ describe 'firewall::linux::redhat', :type => :class do
         it { should contain_service('firewalld').with(
           :ensure => 'stopped',
           :enable => false,
-          :before => 'Package[iptables-services]'
+          :before => ['Package[iptables-services]', 'Service[iptables]']
         )}
 
         it { should contain_package('iptables-services').with(


### PR DESCRIPTION
firewalld must be stopped and disabled before the iptables service
will start properly.