### PR TITLE
(maint) modify to account for spaces in iptables-save output

### DIFF
--- a/spec/acceptance/nflog_spec.rb
+++ b/spec/acceptance/nflog_spec.rb
@@ -42,7 +42,7 @@ describe 'nflog' do
 
     it 'contains the rule' do
       shell('iptables-save') do |r|
-        expect(r.stdout).to match(/NFLOG --nflog-prefix  "#{prefix}"/)
+        expect(r.stdout).to match(/NFLOG --nflog-prefix +"#{prefix}"/)
       end
     end
   end


### PR DESCRIPTION
for nflog_spec we check iptables-save output and for --nflog-prefix, there can be varying amounts of space, so this accounts for that