### PR TITLE
(maint) do not test nflog on older versions of iptables ( < 1.3.7)

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -656,6 +656,11 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
       args << ['--wait']
     end
 
+    #nflog options are not available on older OSes
+    [:nflog_group,:nflog_prefix,:nflog_threshold,:nflog_range].each do |nflog_feature|
+      fail "#{nflog_feature} is not available on iptables version #{iptables_version}" if resource[nflog_feature] && (iptables_version && iptables_version < '1.3.7')
+    end
+
     resource_list.each do |res|
       resource_value = nil
       if (resource[res]) then

--- a/spec/acceptance/nflog_spec.rb
+++ b/spec/acceptance/nflog_spec.rb
@@ -1,6 +1,21 @@
 require 'spec_helper_acceptance'
 
-describe 'nflog' do
+describe 'nflog on older OSes', :if => fact('iptables_version') < '1.3.7' do
+  let(:pp) { <<-EOS
+        class {'::firewall': }
+        firewall { '503 - test':
+          jump  => 'NFLOG',
+          proto => 'all',
+          nflog_group => 3,
+        }
+      EOS
+  }
+  it 'should throw an error' do
+    apply_manifest(pp, :acceptable_error_codes => [0])
+  end
+end
+
+describe 'nflog', :unless => fact('iptables_version') < '1.3.7' do
   describe 'nflog_group' do
 
     let(:group) { 3 }
@@ -14,7 +29,7 @@ describe 'nflog' do
           nflog_group => #{group},
         }
       EOS
-       apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_failures => true)
     end
 
     it 'contains the rule' do


### PR DESCRIPTION
NFLOG is not available as a jump target until iptables version 1.3.7.
This adds an error to the provider when the version is lower than 1.3.7
and the user tries to use NFLOG options. This also updates the tests to
check and make sure the error is thrown on appropriate versions