### PR TITLE
MODULES-4828 version_requirement updated

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.5.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Update the puppetlabs-firewall module version compatibility in the metadata.json to: "version_requirement": ">= 4.7.0 < 5.0.0"
The current version_requirement is listed as ">= 3.5.0 < 5.0.0"