### PR TITLE
(doc) Fix formatting in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
-#firewall
+# firewall
 
 [![Build Status](https://travis-ci.org/puppetlabs/puppetlabs-firewall.png?branch=master)](https://travis-ci.org/puppetlabs/puppetlabs-firewall)
 
-####Table of Contents
+#### Table of Contents
 
 1. [Overview - What is the firewall module?](#overview)
 2. [Module Description - What does the module do?](#module-description)
@@ -422,7 +422,7 @@ Specify the name of the IPv6 ip6tables service. Defaults defined in `firewall::p
 
 Specify the platform-specific package(s) to install. Defaults defined in `firewall::params`.
 
-###Type: firewall
+### Type: firewall
 
 This type enables you to manage firewall rules within Puppet.
 
@@ -645,14 +645,14 @@ If Puppet is managing the iptables or iptables-persistent packages, and the prov
 
 * `name`: The canonical name of the rule. This name is also used for ordering, so make sure you prefix the rule with a number. For example:
 
-  ~~~puppet
+~~~puppet
 firewall { '000 this runs first':
   # this rule will run first
 }
 firewall { '999 this runs last':
   # this rule will run last
 }
-  ~~~
+~~~
 
   Depending on the provider, the name of the rule can be stored using the comment feature of the underlying firewall subsystem. Values must match '/^\d+[[:graph:][:space:]]+$/'.
 

--- a/spec/unit/documentation/readme_spec.rb
+++ b/spec/unit/documentation/readme_spec.rb
@@ -1,0 +1,6 @@
+describe 'formatting in README.markdown' do
+  it 'should not contain badly formatted heading markers' do
+    content = File.read('README.markdown')
+    expect(content).to_not match /^#+[^# ]/
+  end
+end


### PR DESCRIPTION
commit 95f56586a6506ce4c0460106483a7982fbaf4e05
Author: Alex Harvey <Alex_Harvey@amp.com.au>
Date:   Sun Jun 11 22:47:18 2017 +1000

    Add test for README
    
    This adds an Rspec test to fail the build if someone adds incorrectly
    formatted heading markers again.

commit b7b62ec28f9999ca499440838d26733aab530eb8
Author: Alex Harvey <Alex_Harvey@amp.com.au>
Date:   Sun Jun 11 22:31:33 2017 +1000

    (doc) Fix formatting in README.markdown
    
    Without this patch applied, a large chunk of the README is not
    displaying properly on Github.

