### PR TITLE
(MODULES-5111) Support UNTRACKED in state and ctstate rules

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -547,7 +547,7 @@ If Puppet is managing the iptables or iptables-persistent packages, and the prov
 
 * `connmark`: Match the Netfilter mark value associated with the packet. Accepts values `mark/mask` or `mark`. These will be converted to hex if they are not hex already. Requires the `mark` feature.
 
-* `ctstate`: Matches a packet based on its state in the firewall stateful inspection table, using the conntrack module. Valid values are: 'INVALID', 'ESTABLISHED', 'NEW', 'RELATED'. Requires the `state_match` feature.
+* `ctstate`: Matches a packet based on its state in the firewall stateful inspection table, using the conntrack module. Valid values are: 'INVALID', 'ESTABLISHED', 'NEW', 'RELATED', 'UNTRACKED'. Requires the `state_match` feature.
 
 * `date_start`: Start Date/Time for the rule to match, which must be in ISO 8601 "T" notation. The possible time range is '1970-01-01T00:00:00' to '2038-01-19T04:17:07'
 
@@ -784,7 +784,7 @@ firewall { '101 blacklist strange traffic':
 
 * `stat_probability`: Set the probability from 0 to 1 for a packet to be randomly matched. It works only with `stat_mode => 'random'`.
 
-* `state`: Matches a packet based on its state in the firewall stateful inspection table. Valid values are: 'INVALID', 'ESTABLISHED', 'NEW', 'RELATED'. Requires the `state_match` feature.
+* `state`: Matches a packet based on its state in the firewall stateful inspection table. Valid values are: 'INVALID', 'ESTABLISHED', 'NEW', 'RELATED', 'UNTRACKED'. Requires the `state_match` feature.
 
 * `string`: Set the pattern for string matching. Requires the `string_matching` feature.
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -744,9 +744,10 @@ Puppet::Type.newtype(:firewall) do
       * ESTABLISHED
       * NEW
       * RELATED
+      * UNTRACKED
     EOS
 
-    newvalues(:INVALID,:ESTABLISHED,:NEW,:RELATED)
+    newvalues(:INVALID,:ESTABLISHED,:NEW,:RELATED,:UNTRACKED)
 
     # States should always be sorted. This normalizes the resource states to
     # keep it consistent with the sorted result from iptables-save.
@@ -775,9 +776,10 @@ Puppet::Type.newtype(:firewall) do
       * ESTABLISHED
       * NEW
       * RELATED
+      * UNTRACKED
     EOS
 
-    newvalues(:INVALID,:ESTABLISHED,:NEW,:RELATED)
+    newvalues(:INVALID,:ESTABLISHED,:NEW,:RELATED,:UNTRACKED)
 
     # States should always be sorted. This normalizes the resource states to
     # keep it consistent with the sorted result from iptables-save.

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -360,14 +360,19 @@ describe firewall do
       expect(@resource[:state]).to eql [:INVALID]
     end
 
+    it 'should accept value as a string' do
+      @resource[:state] = :UNTRACKED
+      expect(@resource[:state]).to eql [:UNTRACKED]
+    end
+
     it 'should accept value as an array' do
       @resource[:state] = [:INVALID, :NEW]
       expect(@resource[:state]).to eql [:INVALID, :NEW]
     end
 
     it 'should sort values alphabetically' do
-      @resource[:state] = [:NEW, :ESTABLISHED]
-      expect(@resource[:state]).to eql [:ESTABLISHED, :NEW]
+      @resource[:state] = [:NEW, :UNTRACKED, :ESTABLISHED]
+      expect(@resource[:state]).to eql [:ESTABLISHED, :NEW, :UNTRACKED]
     end
   end
 
@@ -375,6 +380,11 @@ describe firewall do
     it 'should accept value as a string' do
       @resource[:ctstate] = :INVALID
       expect(@resource[:ctstate]).to eql [:INVALID]
+    end
+
+    it 'should accept value as a string' do
+      @resource[:state] = :UNTRACKED
+      expect(@resource[:state]).to eql [:UNTRACKED]
     end
 
     it 'should accept value as an array' do


### PR DESCRIPTION
Type updated to permit UNTRACKED to be passed as a valid state
README updated to document above change
Spec tests updated to verify UNTRACKED is accepted for both state and ctstate, and additionally to verify alphabetic ordering still works as expected.

All tests relating to these changes have passed.