### PR TITLE
(MODULES-5340) Understand negated match sets

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -375,7 +375,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     # so it behaves like --comment
     values = values.gsub(/(!\s+)?--tcp-flags (\S*) (\S*)/, '--tcp-flags "\1\2 \3"')
     # --match-set can have multiple values with weird iptables format
-    if values =~ /-m set --match-set/
+    if values =~ /-m set (!\s+)?--match-set/
       values = values.gsub(/(!\s+)?--match-set (\S*) (\S*)/, '--match-set \1\2 \3')
       ind  = values.index('-m set --match-set')
       sets = values.scan(/-m set --match-set ((?:!\s+)?\S* \S*)/)

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -344,6 +344,18 @@ ARGS_TO_HASH = {
       :iniface => 'eth0',
     },
   },
+  'ipset_negated' => {
+    :line => '-A PREROUTING -p tcp -m multiport --dports 1094 -m comment --comment "060 ipset" -m state --state NEW -m set ! --match-set setname1 src -j DROP',
+    :table => 'filter',
+    :params => {
+      :chain => 'PREROUTING',
+      :proto => "tcp",
+      :dport => ['1094'],
+      :state => ['NEW'],
+      :ipset => ['! setname1 src'],
+      :action => 'drop',
+    },
+  },
   'iniface_1_negated' => {
     :line => '-A INPUT ! -i eth0 -j DROP -m comment --comment "060 iniface"',
     :table => 'filter',


### PR DESCRIPTION
This patch allows the provider to understand rules that contain negated
match sets when parsing the ruleset.