### PR TITLE
Update for hashlimit tests to not run on RedHat5 or Scientific 5

### DIFF
--- a/spec/acceptance/hashlimit_spec.rb
+++ b/spec/acceptance/hashlimit_spec.rb
@@ -1,7 +1,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'hashlimit property' do
+describe 'hashlimit property', if: fact('operatingsystemmajrelease') != '5' && (fact('operatingsystem') != 'Scientific' || fact('operatingsystem') != 'RedHat') do
   before :all do
     iptables_flush_all_tables
     ip6tables_flush_all_tables


### PR DESCRIPTION
Hashlimit doesn't seem to be fully supported on these OS'es so I've put a check to skip the tests.