### PR TITLE
(MODULES-5645) Choose correct IP version for hostname resolution

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -134,8 +134,17 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     munge do |value|
+      case @resource[:provider]
+      when :iptables
+        protocol = :IPv4
+      when :ip6tables
+        protocol = :IPv6
+      else
+        self.fail("cannot work out protocol family")
+      end
+
       begin
-        @resource.host_to_mask(value)
+        @resource.host_to_mask(value, protocol)
       rescue Exception => e
         self.fail("host_to_ip failed for #{value}, exception #{e}")
       end
@@ -184,8 +193,17 @@ Puppet::Type.newtype(:firewall) do
     EOS
 
     munge do |value|
+      case @resource[:provider]
+      when :iptables
+        protocol = :IPv4
+      when :ip6tables
+        protocol = :IPv6
+      else
+        self.fail("cannot work out protocol family")
+      end
+
       begin
-        @resource.host_to_mask(value)
+        @resource.host_to_mask(value, protocol)
       rescue Exception => e
         self.fail("host_to_ip failed for #{value}, exception #{e}")
       end

--- a/lib/puppet/util/ipcidr.rb
+++ b/lib/puppet/util/ipcidr.rb
@@ -4,9 +4,9 @@ require 'ipaddr'
 module Puppet
   module Util
     class IPCidr < IPAddr
-      def initialize(ipaddr)
+      def initialize(ipaddr, family = Socket::AF_UNSPEC)
         begin
-          super(ipaddr)
+          super(ipaddr, family)
         rescue ArgumentError => e
           if e.message =~ /invalid address/
             raise ArgumentError, "Invalid address from IPAddr.new: #{ipaddr}"

--- a/spec/unit/puppet/util/firewall_spec.rb
+++ b/spec/unit/puppet/util/firewall_spec.rb
@@ -14,8 +14,9 @@ describe 'Puppet::Util::Firewall' do
   describe '#host_to_ip' do
     subject { resource }
     it {
-      expect(Resolv).to receive(:getaddress).with('puppetlabs.com').and_return('96.126.112.51')
-      expect(subject.host_to_ip('puppetlabs.com')).to eql '96.126.112.51/32'
+      expect(Resolv).to receive(:each_address).at_least(:once).with('puppetlabs.com').and_yield('96.126.112.51').and_yield('2001:DB8:4650::13:8A')
+      expect(subject.host_to_ip('puppetlabs.com', :IPv4)).to eql '96.126.112.51/32'
+      expect(subject.host_to_ip('puppetlabs.com', :IPv6)).to eql '2001:db8:4650::13:8a/128'
     }
     it { expect(subject.host_to_ip('96.126.112.51')).to eql '96.126.112.51/32' }
     it { expect(subject.host_to_ip('96.126.112.51/32')).to eql '96.126.112.51/32' }
@@ -28,22 +29,24 @@ describe 'Puppet::Util::Firewall' do
   describe '#host_to_mask' do
     subject { resource }
     it {
-      expect(Resolv).to receive(:getaddress).at_least(:once).with('puppetlabs.com').and_return('96.126.112.51')
-      expect(subject.host_to_mask('puppetlabs.com')).to eql '96.126.112.51/32'
-      expect(subject.host_to_mask('!puppetlabs.com')).to eql '! 96.126.112.51/32'
+      expect(Resolv).to receive(:each_address).at_least(:once).with('puppetlabs.com').and_yield('96.126.112.51').and_yield('2001:DB8:4650::13:8A')
+      expect(subject.host_to_mask('puppetlabs.com', :IPv4)).to eql '96.126.112.51/32'
+      expect(subject.host_to_mask('!puppetlabs.com', :IPv4)).to eql '! 96.126.112.51/32'
+      expect(subject.host_to_mask('puppetlabs.com', :IPv6)).to eql '2001:db8:4650::13:8a/128'
+      expect(subject.host_to_mask('!puppetlabs.com', :IPv6)).to eql '! 2001:db8:4650::13:8a/128'
     }
-    it { expect(subject.host_to_mask('96.126.112.51')).to eql '96.126.112.51/32' }
-    it { expect(subject.host_to_mask('!96.126.112.51')).to eql '! 96.126.112.51/32' }
-    it { expect(subject.host_to_mask('96.126.112.51/32')).to eql '96.126.112.51/32' }
-    it { expect(subject.host_to_mask('! 96.126.112.51/32')).to eql '! 96.126.112.51/32' }
-    it { expect(subject.host_to_mask('2001:db8:85a3:0:0:8a2e:370:7334')).to eql '2001:db8:85a3::8a2e:370:7334/128' }
-    it { expect(subject.host_to_mask('!2001:db8:85a3:0:0:8a2e:370:7334')).to eql '! 2001:db8:85a3::8a2e:370:7334/128' }
-    it { expect(subject.host_to_mask('2001:db8:1234::/48')).to eql '2001:db8:1234::/48' }
-    it { expect(subject.host_to_mask('! 2001:db8:1234::/48')).to eql '! 2001:db8:1234::/48' }
-    it { expect(subject.host_to_mask('0.0.0.0/0')).to eql nil }
-    it { expect(subject.host_to_mask('!0.0.0.0/0')).to eql nil }
-    it { expect(subject.host_to_mask('::/0')).to eql nil }
-    it { expect(subject.host_to_mask('! ::/0')).to eql nil }
+    it { expect(subject.host_to_mask('96.126.112.51', :IPv4)).to eql '96.126.112.51/32' }
+    it { expect(subject.host_to_mask('!96.126.112.51', :IPv4)).to eql '! 96.126.112.51/32' }
+    it { expect(subject.host_to_mask('96.126.112.51/32', :IPv4)).to eql '96.126.112.51/32' }
+    it { expect(subject.host_to_mask('! 96.126.112.51/32', :IPv4)).to eql '! 96.126.112.51/32' }
+    it { expect(subject.host_to_mask('2001:db8:85a3:0:0:8a2e:370:7334', :IPv6)).to eql '2001:db8:85a3::8a2e:370:7334/128' }
+    it { expect(subject.host_to_mask('!2001:db8:85a3:0:0:8a2e:370:7334', :IPv6)).to eql '! 2001:db8:85a3::8a2e:370:7334/128' }
+    it { expect(subject.host_to_mask('2001:db8:1234::/48', :IPv6)).to eql '2001:db8:1234::/48' }
+    it { expect(subject.host_to_mask('! 2001:db8:1234::/48', :IPv6)).to eql '! 2001:db8:1234::/48' }
+    it { expect(subject.host_to_mask('0.0.0.0/0', :IPv4)).to eql nil }
+    it { expect(subject.host_to_mask('!0.0.0.0/0', :IPv4)).to eql nil }
+    it { expect(subject.host_to_mask('::/0', :IPv6)).to eql nil }
+    it { expect(subject.host_to_mask('! ::/0', :IPv6)).to eql nil }
   end
 
   describe '#icmp_name_to_number' do


### PR DESCRIPTION
Currently hostnames specified in a `source` or `destination` field
in a firewall rule are always resolved as IPv4, even when the
provider is `ip6tables`. Instead, intelligently determine whether
the hostname should be resolved as an IPv4 address or IPv6 address
based on the provider.