### PR TITLE
Debian 9 iptables -L returns 2 consecutive spaces

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -648,7 +648,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
 
   def delete_args
     # Split into arguments
-    line = properties[:line].gsub(/^\-A /, '-D ').split(/\s(?=(?:[^"]|"[^"]*")*$)/).map{|v| v.gsub(/^"/, '').gsub(/"$/, '')}
+    line = properties[:line].gsub(/^\-A /, '-D ').split(/\s+(?=(?:[^"]|"[^"]*")*$)/).map{|v| v.gsub(/^"/, '').gsub(/"$/, '')}
     line.unshift("-t", properties[:table])
   end
 


### PR DESCRIPTION
Debian 9 iptables -L returns 2 consecutive spaces beetween 'nflog-prefix' and the prefix itself.
The delete_args returns en extra argument, so the rule doesn't get removed.
Matching one space or more in the function regex resolves this problem.

See issue : https://tickets.puppetlabs.com/browse/MODULES-5692