### PR TITLE
[MODULES-5924] Fix unmanaged rule regex when updating a iptable.

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -799,7 +799,7 @@ Puppet::Type.type(:firewall).provide :iptables, :parent => Puppet::Provider::Fir
     my_rule = resource[:name].to_s
     rules << my_rule
 
-    unmanaged_rule_regex = /^9[0-9]{3}\s[a-f0-9]{32}$/
+    unmanaged_rule_regex = /^9[0-9]{3}\s.*$/
     # Find if this is a new rule or an existing rule, then find how many
     # unmanaged rules preceed it.
     if rules.length == rules.uniq.length


### PR DESCRIPTION
We have two kind of unmanaged rules:

- empty comment: those get an md5 hash as a name prefixed with 90XX
- comment not matching “\d[graph,space]+$”

This is defined there[1]

But when we calculate the updated line we take into account only the
first kind of unmanaged rule in the offset[2] which leads to error.

Relaxing the regex solves this.

[1] https://github.com/puppetlabs/puppetlabs-firewall/blob/master/lib/puppet/provider/firewall/iptables.rb#L610..L617
[2] https://github.com/puppetlabs/puppetlabs-firewall/blob/master/lib/puppet/provider/firewall/iptables.rb#L802..L803