### PR TITLE
(MODULES-6092) Set correct seluser for CentOS/RHEL 5.x

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -106,6 +106,11 @@ class firewall::linux::redhat (
       case $::operatingsystem {
         'CentOS': {
           case $::operatingsystemrelease {
+            /^5\..*/: {
+              File["/etc/sysconfig/${service_name}"] { seluser => 'system_u', seltype => 'etc_t' }
+              File["/etc/sysconfig/${service_name_v6}"] { seluser => 'system_u', seltype => 'etc_t' }
+            }
+
             /^6\..*/: {
               File["/etc/sysconfig/${service_name}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' }
               File["/etc/sysconfig/${service_name_v6}"] { seluser => 'unconfined_u', seltype => 'system_conf_t' }


### PR DESCRIPTION
In 1.10.0, applying the puppetlabs-firewall module on CentOS/RHEL 5.x produces warnings:

Warning: Failed to set SELinux context unconfined_u:object_r:etc_t on /etc/sysconfig/iptables
Notice: /Stage[main]/Firewall::Linux::Redhat/File[/etc/sysconfig/iptables]/seluser: seluser changed 'system_u' to 'unconfined_u'
Warning: Failed to set SELinux context unconfined_u:object_r:etc_t on /etc/sysconfig/ip6tables
Notice: /Stage[main]/Firewall::Linux::Redhat/File[/etc/sysconfig/ip6tables]/seluser: seluser changed 'system_u' to 'unconfined_u'

This commit adds a case to set the correct seluser.