### PR TITLE
Remove leftover debugging 'puts'

### DIFF
--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -217,7 +217,6 @@ describe 'iptables provider' do
         let(:resource) { provider.rule_to_hash(data[:line], data[:table], 0) }
         # If this option is enabled, make sure the error was raised
         if data[:produce_warning] then
-          puts data
           it "the input rules should produce a warning by rules_to_hash" do
             expect(provider).to receive(:warning).with(/Skipping unparsable iptables rule/)
             resource  # force resource to get evaluated


### PR DESCRIPTION
I used the puts to figure out rspec behavior and forgot to remove it
before commiting a fix.