### PR TITLE
MODULES-6261: Fix error parsing rules with dashes in the chain name

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -394,7 +394,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
       values.insert(ind, "-m set --match-set \"#{sets.join(';')}\" ")
     end
     # we do a similar thing for negated address masks (source and destination).
-    values = values.gsub(%r{(-\S+) (!)\s?(\S*)}, '\1 "\2 \3"')
+    values = values.gsub(%r{(?<=\s)(-\S+) (!)\s?(\S*)}, '\1 "\2 \3"')
     # fix negated physdev rules
     values = values.gsub(%r{-m physdev ! (--physdev-is-\S+)}, '-m physdev \1 "!"')
     # the actual rule will have the ! mark before the option.

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -365,6 +365,15 @@ ARGS_TO_HASH = {
       :iniface => '! eth0',
     },
   },
+  'iniface_2_negated' => {
+    :line => '-A CHAIN-WITH-DASH ! -i eth0 -p tcp -m comment --comment "005 iniface 2" -j DROP',
+    :table => 'filter',
+    :params => {
+      :action => 'drop',
+      :chain => 'CHAIN-WITH-DASH',
+      :iniface => '! eth0',
+    },
+  },
   'iniface_1_aliased' => {
     :line => '-A INPUT -i eth0:1 -j DROP -m comment --comment "060 iniface"',
     :table => 'filter',


### PR DESCRIPTION
Add a a zero width lookbehind to the regex that processes negations to avoid matching the dash in the chain name.  