### PR TITLE
MODULES-2119 ip6tables delete -p all exception

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -661,6 +661,17 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
   def delete_args
     # Split into arguments
     line = properties[:line].gsub(%r{^\-A }, '-D ').split(%r{\s+(?=(?:[^"]|"[^"]*")*$)}).map { |v| v.gsub(%r{^"}, '').gsub(%r{"$}, '') }
+    if (self.class.instance_variable_get(:@protocol) == "IPv6" and properties[:proto] == "all") then
+      #
+      # There is currently a bug in ip6tables where delete rules do not match rules using any protocol
+      # if '-p' all is missing.
+      #
+      # https://bugzilla.netfilter.org/show_bug.cgi?id=1015
+      #
+      # This check looks for this case, and adds '-p all' to the rule for ipv6.
+      #
+      line = line.concat ["-p", "all"]
+    end
     line.unshift('-t', properties[:table])
   end
 

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -435,4 +435,34 @@ describe 'ip6tables provider' do
       end
     end
   end
+
+  describe 'when deleting ipv6 resources' do
+    let(:sample_rule) do
+      '-A INPUT -i lo -m comment --comment "001 accept all to lo interface v6" -j ACCEPT'
+    end
+
+    let(:bare_sample_rule) do
+      '-A INPUT -i lo -m comment --comment 001 accept all to lo interface v6 -j ACCEPT'
+    end
+
+    let(:resource) { provider6.rule_to_hash(sample_rule, 'filter', 0) }
+    let(:instance) { provider6.new(resource) }
+
+    it 'resource[:line] looks like the original rule' do
+      resource[:line] == sample_rule
+    end
+
+    it 'delete_args is an array' do
+      expect(instance.delete_args.class).to eq(Array)
+    end
+
+    it 'attempts to match ipv6 rule' do
+      expect(instance.delete_args).to eq(["-t", "filter", "-D", "INPUT", "-i", "lo", "-m", "comment", "--comment", "001 accept all to lo interface v6", "-j", "ACCEPT", "-p", "all"])
+    end
+
+    it 'delete_args is the same as the rule string when joined' do
+      expect(instance.delete_args.join(' ')).to eq(bare_sample_rule.gsub(%r{\-A},
+                                                                    '-t filter -D') + " -p all")
+    end
+  end
 end


### PR DESCRIPTION
There is currently a bug in ip6tables which will not match an expression which impacts all L4 protocols, if 'all' as a protocol is not specified (-p all), even though this works with standard version 4 iptables.  This PR works around this bug in ip6tables.  The real fix is in the upstream ip6tables code(bug here:  https://bugzilla.netfilter.org/show_bug.cgi?id=1015)  But this bug has been open for two years.  

Ticket Link: https://tickets.puppetlabs.com/browse/MODULES-2119 (This PR was inspired by code in that ticket)

Without this code, if anyone uses the "all" protocol in an ipv6 rule, the module will be unable to delete the rule. 

I tested this in a vagrant box, by removing and re-adding the conditional, to see if it would fail to delete the rule.