### PR TITLE
(MODULES-6129) negated option with address mask bugfix

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -393,12 +393,12 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
       values = values.gsub(%r{-m set --match-set (!\s+)?\S* \S* }, '')
       values.insert(ind, "-m set --match-set \"#{sets.join(';')}\" ")
     end
+    # the actual rule will have the ! mark before the option.
+    values = values.gsub(%r{(!)\s*(-\S+)\s*(\S*)}, '\2 "\1 \3"')
     # we do a similar thing for negated address masks (source and destination).
     values = values.gsub(%r{(?<=\s)(-\S+) (!)\s?(\S*)}, '\1 "\2 \3"')
     # fix negated physdev rules
     values = values.gsub(%r{-m physdev ! (--physdev-is-\S+)}, '-m physdev \1 "!"')
-    # the actual rule will have the ! mark before the option.
-    values = values.gsub(%r{(!)\s*(-\S+)\s*(\S*)}, '\2 "\1 \3"')
     # The match extension for tcp & udp are optional and throws off the @resource_map.
     values = values.gsub(%r{(?!-m tcp --tcp-flags)-m (tcp|udp) }, '')
     # There is a bug in EL5 which puts 2 spaces before physdev, so we fix it


### PR DESCRIPTION
This fixes the issues with rules in the following format (e. g. used by Docker),
where exclamation mark precedes an option followed by outiface:

```
"-A FORWARD -i br-123456 ! -o br-123456 -j ACCEPT"
```

Without the fix, it is being parsed like [this:](https://github.com/puppetlabs/puppetlabs-firewall/blob/master/lib/puppet/provider/firewall/iptables.rb#L396)
```
# we do a similar thing for negated address masks (source and destination).
values = values.gsub(/(-\S+) (!)\s?(\S*)/,'\1 "\2 \3"')
#=> "-A FORWARD -i br-123456 \"! -o\" br-123456 -j ACCEPT"

# the actual rule will have the ! mark before the option.
values = values.gsub(/(!)\s*(-\S+)\s*(\S*)/, '\2 "\1 \3"')
#=> "-A FORWARD br-123456 \"-o\" \"! br-123456\" ACCEPT"
```
Which, in the end, results in:
```
values = ["ACCEPT", "\"! br-123456\"", "\"-o\"", "br-123456", "FORWARD"]
keys = [:jump, :iniface, :chain]
Error: Failed to apply catalog: Parser error: keys (3) and values (5) count mismatch on line: -A FORWARD -i br-123456 ! -o br-123456 -j ACCEPT
```

The simple solution is to switch those two gsubs, so it shifts the ! behind option first and only then it quotes the ! together with an option argument (e.g. outiface):
```
values = values.gsub(/(!)\s*(-\S+)\s*(\S*)/, '\2 "\1 \3"')
#=> "-A FORWARD -i br-123456 ! -o br-123456 -j ACCEPT"

values = values.gsub(/(-\S+) (!)\s?(\S*)/,'\1 "\2 \3"')
#=> "-A FORWARD -i br-123456 -o \"! br-123456\" -j ACCEPT"
```
A value in this format is then picked up by the parser correctly.