### PR TITLE
(maint) Add example unit test of a resource in a manifest

### DIFF
--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -1,0 +1,9 @@
+node 'actual.resource' {
+  firewall { '102 Monitoring 22 tcp access':
+    chain       => 'DOCKER',
+    dport       => 22,
+    destination => '172.30.0.3',
+    proto       => 'tcp',
+    action      => 'accept',
+  }
+}

--- a/spec/hosts/firewall_spec.rb
+++ b/spec/hosts/firewall_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'actual.resource' do
+  with_debian_facts
+
+  it { is_expected.to compile }
+end


### PR DESCRIPTION
This provides an example of a firewall resource in a manifest to check munging without providers and other codepaths not easily testible via type & provider unit tests.