### PR TITLE
(FM-7516) - Removing Gentoo from metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -65,12 +65,6 @@
         "16.04",
         "18.04"
       ]
-    },
-    {
-      "operatingsystem": "Gentoo",
-      "operatingsystemrelease": [
-        "1.0"
-      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
Gentoo is an entry in the metadata, removing this entry as we do not
have our test infrastructure set up to run acceptance test on this
OS. Removing from the metadata means that we will not support this OS,
however no code changes are being made therefore this OS may still be
compatible.