### PR TITLE
add -g flag handling in ip6tables.rb provider

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -77,6 +77,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     dst_type: '--dst-type',
     gateway: '--gateway',
     gid: '--gid-owner',
+    goto: '-g',
     hop_limit: '-m hl --hl-eq',
     icmp: '-m icmp6 --icmpv6-type',
     iniface: '-i',


### PR DESCRIPTION
In lib/puppet/provider/firewall/ip6tables.rb there is no goto: entry for the -g flag in @resource_map which leads to errors for rules using that feature. 

lib/puppet/type/firewall.rb already handles this flag. It's a one-line change to recognize it. The right rules then get into the chains in my testing.