### PR TITLE
Amazon linux 2 changed its major version to 2 with the last update...

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -67,7 +67,8 @@ class firewall::linux::redhat (
     }
   }
 
-  if ($::operatingsystem == 'Amazon') and (versioncmp($::operatingsystemmajrelease, '4') >= 0) {
+  if ($::operatingsystem == 'Amazon') and (versioncmp($::operatingsystemmajrelease, '4') >= 0)
+    or ($::operatingsystem == 'Amazon') and (versioncmp($::operatingsystemmajrelease, '2') >= 0) {
     service { $service_name:
       ensure    => $ensure,
       enable    => $enable,


### PR DESCRIPTION
This fix allows both major versions for Amazon linux 2