### PR TITLE
Add nftables wrapper support for RHEL8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,24 +3,39 @@ class firewall::params {
   $package_ensure = 'present'
   case $::osfamily {
     'RedHat': {
-      $service_name = 'iptables'
-      $service_name_v6 = 'ip6tables'
       case $::operatingsystem {
         'Amazon': {
+          $service_name = 'iptables'
+          $service_name_v6 = 'ip6tables'
           $package_name = undef
+          $sysconfig_manage = true
         }
         'Fedora': {
+          $service_name = 'iptables'
+          $service_name_v6 = 'ip6tables'
           if versioncmp($::operatingsystemrelease, '15') >= 0 {
             $package_name = 'iptables-services'
           } else {
             $package_name = undef
           }
+          $sysconfig_manage = true
         }
         default: {
-          if versioncmp($::operatingsystemrelease, '7.0') >= 0 {
+          if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
+            $service_name = 'nftables'
+            $service_name_v6 = undef
+            $package_name = 'nftables'
+            $sysconfig_manage = false
+          } elsif versioncmp($::operatingsystemrelease, '7.0') >= 0 {
+            $service_name = 'iptables'
+            $service_name_v6 = 'ip6tables'
             $package_name = 'iptables-services'
+            $sysconfig_manage = true
           } else {
+            $service_name = 'iptables'
+            $service_name_v6 = 'ip6tables'
             $package_name = 'iptables-ipv6'
+            $sysconfig_manage = true
           }
         }
       }


### PR DESCRIPTION
In RHEL8, iptables is replaced with nftables under the covers. In order
to allow for the firewall module to continue to function, this change
updates the redhat firewall configuration to pull in the nftables
packages.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/html/8.0_beta_release_notes/new-features#networking_2