### PR TITLE
External control for iptables-persistent

### DIFF
--- a/manifests/linux/debian.pp
+++ b/manifests/linux/debian.pp
@@ -30,10 +30,10 @@ class firewall::linux::debian (
 
         refreshonly => true,
     }
-    package { $package_name:
+    ensure_packages([$package_name],{
       ensure  => $package_ensure,
-      require => Exec['iptables-persistent-debconf'],
-    }
+      require => Exec['iptables-persistent-debconf']
+    })
   }
 
   if($::operatingsystemrelease =~ /^6\./ and $enable == true and $::iptables_persistent_version


### PR DESCRIPTION
Often, the iptables-persistent package in debian-based distributions is controlled by external modules. Can I replace the package installation with `package{}` on `ensure_pacakges()`?