### PR TITLE
(MODULES-6340) - Address failure when name begins with 9XXX

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -187,6 +187,8 @@ There are two kinds of firewall rules you can use with firewall: default rules a
 
 All rules employ a numbering system in the resource's title that is used for ordering. When titling your rules, make sure you prefix the rule with a number, for example, '000 accept all icmp requests'. _000_ runs first, _999_ runs last.
 
+**Note:** The ordering range 9000-9999 is reserved for unmanaged rules. Do not specify any firewall rules in this range.
+
 ### Default rules
 
 You can place default rules in either `my_fw::pre` or `my_fw::post`, depending on when you would like them to run. Rules placed in the `pre` class will run first, and rules in the `post` class, last.

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -876,6 +876,8 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
 
     # Insert our new or updated rule in the correct order of named rules, but
     # offset for unnamed rules.
-    rules.reject { |r| r.match(unmanaged_rule_regex) }.sort.index(my_rule) + 1 + unnamed_offset
+    sorted_rules = rules.reject { |r| r.match(unmanaged_rule_regex) }.sort
+    raise 'Invalid ordering value in resource name. The range 9000-9999 is reserved for unmanaged rules.' if sorted_rules.index(my_rule).nil?
+    sorted_rules.index(my_rule) + 1 + unnamed_offset
   end
 end

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -877,7 +877,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     # Insert our new or updated rule in the correct order of named rules, but
     # offset for unnamed rules.
     sorted_rules = rules.reject { |r| r.match(unmanaged_rule_regex) }.sort
-    raise 'Invalid ordering value in resource name. The range 9000-9999 is reserved for unmanaged rules.' if sorted_rules.index(my_rule).nil?
+    raise 'Rule sorting error. Make sure that the title of your rule does not start with 9000-9999, as this range is reserved.' if sorted_rules.index(my_rule).nil?
     sorted_rules.index(my_rule) + 1 + unnamed_offset
   end
 end

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -36,7 +36,7 @@ describe 'firewall basics', docker: true do
       PUPPETCODE
       it 'fails' do
         apply_manifest(pp, expect_failures: true) do |r|
-          expect(r.stderr).to match(%r{Invalid ordering value})
+          expect(r.stderr).to match(%r{Ordering error detected})
         end
       end
     end

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -36,7 +36,7 @@ describe 'firewall basics', docker: true do
       PUPPETCODE
       it 'fails' do
         apply_manifest(pp, expect_failures: true) do |r|
-          expect(r.stderr).to match(%r{Ordering error detected})
+          expect(r.stderr).to match(%r{Rule sorting error})
         end
       end
     end

--- a/spec/acceptance/firewall_spec.rb
+++ b/spec/acceptance/firewall_spec.rb
@@ -28,6 +28,18 @@ describe 'firewall basics', docker: true do
         end
       end
     end
+
+    context 'when invalid ordering range specified' do
+      pp = <<-PUPPETCODE
+          class { '::firewall': }
+          firewall { '9946 test': ensure => present }
+      PUPPETCODE
+      it 'fails' do
+        apply_manifest(pp, expect_failures: true) do |r|
+          expect(r.stderr).to match(%r{Invalid ordering value})
+        end
+      end
+    end
   end
 
   describe 'ensure' do


### PR DESCRIPTION
When a user specifies a firewall rule starting with a value between 9000-9999, the following error is thrown:

```Error: Could not set 'present' on ensure: undefined method `+' for nil:NilClass at /root/manifest.pp:2```

The following change addresses this by raising a more appropriate error and providing information in the README as to why this error occurs.