### PR TITLE
Support for Debian Unstable

### DIFF
--- a/lib/facter/iptables_persistent_version.rb
+++ b/lib/facter/iptables_persistent_version.rb
@@ -6,7 +6,8 @@ Facter.add(:iptables_persistent_version) do
     os = Facter.value(:operatingsystem)
     os_release = Facter.value(:operatingsystemrelease)
     cmd = if (os == 'Debian' && (Puppet::Util::Package.versioncmp(os_release, '8.0') >= 0)) ||
-             (os == 'Ubuntu' && (Puppet::Util::Package.versioncmp(os_release, '14.10') >= 0))
+             (os == 'Ubuntu' && (Puppet::Util::Package.versioncmp(os_release, '14.10') >= 0)) ||
+             (os == 'Debian' && os_release == 'unstable')
             "dpkg-query -Wf '${Version}' netfilter-persistent 2>/dev/null"
           else
             "dpkg-query -Wf '${Version}' iptables-persistent 2>/dev/null"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class firewall::params {
       $service_name_v6 = undef
       case $::operatingsystem {
         'Debian': {
-          if facts['os']['release']['major'] == 'buster/sid' {
+          if $facts['os']['release']['major'] == 'buster/sid' {
             $service_name = 'netfilter-persistent'
             $package_name = 'netfilter-persistent'
           }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,11 @@ class firewall::params {
       $service_name_v6 = undef
       case $::operatingsystem {
         'Debian': {
-          if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
+          if facts['os']['release']['major'] = 'buster/sid' {
+            $service_name = 'netfilter-persistent'
+            $package_name = 'netfilter-persistent'
+          }
+          elsif versioncmp($::operatingsystemrelease, '8.0') >= 0 {
             $service_name = 'netfilter-persistent'
             $package_name = 'iptables-persistent'
           } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class firewall::params {
       $service_name_v6 = undef
       case $::operatingsystem {
         'Debian': {
-          if facts['os']['release']['major'] = 'buster/sid' {
+          if facts['os']['release']['major'] == 'buster/sid' {
             $service_name = 'netfilter-persistent'
             $package_name = 'netfilter-persistent'
           }


### PR DESCRIPTION
adding support for Debian's unstable branch.

note: you may have to purge any rules from iptables-legacy (running "$sudo apt purge iptables-persistent" before re-running puppet.)

I am relatively new to unit testing, so some guidance there would be appreciated if applicable.
