### PR TITLE
(MODULES-8648) - Fix for failures on SLES 11

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -828,7 +828,7 @@ If Puppet is managing the iptables or iptables-persistent packages, and the prov
 
 * `stat_probability`: Set the probability from 0 to 1 for a packet to be randomly matched. It works only with `stat_mode => 'random'`.
 
-* `state`: Matches a packet based on its state in the firewall stateful inspection table. Valid values are: 'INVALID', 'ESTABLISHED', 'NEW', 'RELATED', 'UNTRACKED'. Requires the `state_match` feature.
+* `state`: Matches a packet based on its state in the firewall stateful inspection table. Valid values are: 'INVALID', 'ESTABLISHED', 'NEW', 'RELATED', 'UNTRACKED'. Requires the `state_match` feature. Usage of this is considered to be deprecated and obsolete on SLES 11 SP4, as such it is advisable to use the `ctstate` parameter in it's place.
 
 * `string`: Set the pattern for string matching. Requires the `string_matching` feature.
 

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -140,6 +140,11 @@ class firewall::linux::redhat (
         case $::operatingsystem {
           'CentOS': {
             case $::operatingsystemrelease {
+              /^5\..*/: {
+                $seluser = 'system_u'
+                $seltype = 'etc_t'
+              }
+
               /^6\..*/: {
                 $seluser = 'unconfined_u'
                 $seltype = 'system_conf_t'

--- a/spec/acceptance/invert_spec.rb
+++ b/spec/acceptance/invert_spec.rb
@@ -15,7 +15,7 @@ describe 'firewall inverting' do
         }
         firewall { '602 drop NEW external website packets with FIN/RST/ACK set and SYN unset':
           chain     => 'INPUT',
-          state     => 'NEW',
+          ctstate     => 'NEW',
           action    => 'drop',
           proto     => 'tcp',
           sport     => ['! http', '! 443'],


### PR DESCRIPTION
SLES 11 Sp4 seems to default to ‘-m conntrack’ rather than ‘-m state’
In addition, adding back a piece of code for Centos 5