### PR TITLE
Bug - Ensure that iptables-services package is installed before attem…

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -42,6 +42,15 @@ class firewall::linux::redhat (
   # RHEL 7 / CentOS 7 and later and Fedora 15 and later require the iptables-services
   # package, which provides the /usr/libexec/iptables/iptables.init used by
   # lib/puppet/util/firewall.rb.
+  # The package_name variable is defined by the firewall::params class
+
+  if $package_name {
+    package { $package_name:
+      ensure => $package_ensure,
+      before => Service[$service_name],
+    }
+  }
+
   if ($::operatingsystem != 'Amazon')
     and (($::operatingsystem != 'Fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)
     or  ($::operatingsystem == 'Fedora' and versioncmp($::operatingsystemrelease, '15') >= 0)) {
@@ -58,12 +67,6 @@ class firewall::linux::redhat (
     warning('No v6 service available, $ensure_v6 and $enable_v6 are ignored')
   }
 
-  if $package_name {
-    package { $package_name:
-      ensure => $package_ensure,
-      before => Service[$service_name],
-    }
-  }
 
   if ($::operatingsystem != 'Amazon')
     and (($::operatingsystem != 'Fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -130,11 +130,13 @@ describe 'firewall::linux::redhat', type: :class do
         end
 
         it {
-          is_expected.to contain_service('firewalld').with(
-            ensure: 'stopped',
-            enable: false,
-            before: ['Package[iptables-services]', 'Service[iptables]'],
-          )
+          is_expected.to contain_service('firewalld')
+            .with(
+              ensure: 'stopped',
+              enable: false,
+            )
+            .that_comes_before('Package[iptables-services]')
+            .that_comes_before('Service[iptables]')
         }
 
         it {


### PR DESCRIPTION
The iptables-services package was not being installed before puppet would attempt to start iptables.  This results in puppet errors on nodes which do not have the iptables-services package installed.