### PR TITLE
(MODULES-8736) IPtables support on RHEL8

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -59,10 +59,10 @@ class firewall::linux::redhat (
   }
 
   if $package_name {
-    package { $package_name:
-      ensure => $package_ensure,
-      before => Service[$service_name],
-    }
+    ensure_packages($package_name, {
+        'ensure' => $package_ensure,
+        'before' => Service[$service_name]}
+    )
   }
 
   if ($::operatingsystem != 'Amazon')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,9 +22,9 @@ class firewall::params {
         }
         default: {
           if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
-            $service_name = 'nftables'
-            $service_name_v6 = undef
-            $package_name = 'nftables'
+            $service_name = ['iptables', 'nftables']
+            $service_name_v6 = 'ip6tables'
+            $package_name = ['iptables-services', 'nftables']
             $sysconfig_manage = false
           } elsif versioncmp($::operatingsystemrelease, '7.0') >= 0 {
             $service_name = 'iptables'

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -165,7 +165,10 @@ describe 'firewall::linux::redhat', type: :class do
             ensure: 'running',
             enable: 'true',
           )
-          is_expected.not_to contain_service('iptables')
+          is_expected.to contain_service('iptables').with(
+            ensure: 'running',
+            enable: 'true',
+          )
         }
 
         context 'with ensure => stopped' do
@@ -173,6 +176,9 @@ describe 'firewall::linux::redhat', type: :class do
 
           it {
             is_expected.to contain_service('nftables').with(
+              ensure: 'stopped',
+            )
+            is_expected.to contain_service('iptables').with(
               ensure: 'stopped',
             )
           }
@@ -185,6 +191,9 @@ describe 'firewall::linux::redhat', type: :class do
             is_expected.to contain_service('nftables').with(
               enable: 'false',
             )
+            is_expected.to contain_service('iptables').with(
+              enable: 'false',
+            )
           }
         end
 
@@ -192,14 +201,21 @@ describe 'firewall::linux::redhat', type: :class do
           is_expected.to contain_service('firewalld').with(
             ensure: 'stopped',
             enable: false,
-            before: ['Package[nftables]', 'Service[nftables]'],
+            before: ['Package[iptables-services]', 'Package[nftables]', 'Service[iptables]', 'Service[nftables]'],
+          )
+        }
+
+        it {
+          is_expected.to contain_package('iptables-services').with(
+            ensure: 'present',
+            before: ['Service[iptables]', 'Service[nftables]'],
           )
         }
 
         it {
           is_expected.to contain_package('nftables').with(
             ensure: 'present',
-            before: 'Service[nftables]',
+            before: ['Service[iptables]', 'Service[nftables]'],
           )
         }
 


### PR DESCRIPTION
In order to persist the nftables rules on RHEL8, we need the init scripts:
"Warning: Firewall[998 log all ipv4](provider=iptables): Unable to persist firewall rules:
Execution of '/usr/libexec/iptables/iptables.init save' returned 1:
Error: Could not execute posix command: No such file or directory - /usr/libexec/iptables/iptables.init",

Those are contained in the iptables-services package, so this patch aims
to add it into package_name for RHEL8.

Also, to make the IPtables-managed rules persistent at reboot, we need
to enable iptables (and ip6tables) service(s) like we did in previous
versions of RHEL ecosystem.