### PR TITLE
(MODULES-8855) Move ipvs test to exception spec

### DIFF
--- a/spec/acceptance/firewall_attributes_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_happy_path_spec.rb
@@ -349,12 +349,6 @@ describe 'firewall attribute testing, happy path' do
             chain          => 'OUTPUT',
             table          => 'mangle',
           }
-          firewall { '1002 - set ipvs':
-            proto          => 'tcp',
-            action         => accept,
-            chain          => 'INPUT',
-            ipvs           => true,
-          }
       PUPPETCODE
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: do_catch_changes)
@@ -507,9 +501,6 @@ describe 'firewall attribute testing, happy path' do
     end
     it 'jump is set' do
       expect(result.stdout).to match(%r{-A INPUT -p tcp -m comment --comment "567 - jump" -j TEST})
-    end
-    it 'ipvs is set' do
-      expect(result.stdout).to match(%r{-A INPUT -p tcp -m ipvs --ipvs -m comment --comment "1002 - set ipvs" -j ACCEPT})
     end
   end
 end


### PR DESCRIPTION
ipvs not on RedHat 5/6 by default so moving this to exception spec to fix failing tests.