### PR TITLE
Typo fixes

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -619,7 +619,7 @@ Puppet::Type.newtype(:firewall) do
       unless value =~ %r{^[a-zA-Z0-9\-_]+$}
         raise ArgumentError, <<-PUPPETCODE
           Jump destination must consist of alphanumeric characters, an
-          underscore or a yphen.
+          underscore or a hyphen.
         PUPPETCODE
       end
 
@@ -652,7 +652,7 @@ Puppet::Type.newtype(:firewall) do
       unless value =~ %r{^[a-zA-Z0-9\-_]+$}
         raise ArgumentError, <<-PUPPETCODE
           Goto destination must consist of alphanumeric characters, an
-          underscore or a yphen.
+          underscore or a hyphen.
         PUPPETCODE
       end
 

--- a/lib/puppet/type/firewallchain.rb
+++ b/lib/puppet/type/firewallchain.rb
@@ -49,8 +49,8 @@ Puppet::Type.newtype(:firewallchain) do
 
     validate do |value|
       if value !~ NAME_FORMAT
-        raise ArgumentError, 'Inbuilt chains must be in the form {chain}:{table}:{protocol} where {table} is one of FILTER,' \
-            ' NAT, MANGLE, RAW, RAWPOST, BROUTE, SECURITY or empty (alias for filter), chain can be anything without colons' \
+        raise ArgumentError, 'Inbuilt chains must be in the form {chain}:{table}:{protocol} where {table} is one of filter,' \
+            ' nat, mangle, raw, rawpost, broute, security or empty (alias for filter), chain can be anything without colons' \
             ' or one of PREROUTING, POSTROUTING, BROUTING, INPUT, FORWARD, OUTPUT for the inbuilt chains, and {protocol} being' \
             " IPv4, IPv6, ethernet (ethernet bridging) got '#{value}' table:'#{Regexp.last_match(1)}' chain:'#{Regexp.last_match(2)}' protocol:'#{Regexp.last_match(3)}'"
       else


### PR DESCRIPTION
I've just fixed a couple of typos I noticed while using the module, the word 'yphen' where it should be 'hyphen' and the case of the argument error when creating a chain.