### PR TITLE
(FM-8025) Add RedHat 8 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/acceptance/firewall_attributes_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_exceptions_spec.rb
@@ -1001,7 +1001,9 @@ describe 'firewall basics', docker: true do
         end
       end
     end
+  end
 
+  unless (os[:family] == 'redhat' && os[:release].start_with?('5', '6', '8')) || (os[:family] == 'sles')
     describe 'time tests' do
       context 'when set all time parameters' do
         pp1 = <<-PUPPETCODE

--- a/spec/acceptance/firewall_attributes_ipv6_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_ipv6_exceptions_spec.rb
@@ -213,6 +213,42 @@ describe 'firewall ipv6 attribute testing, exceptions' do
         end
       end
     end
+
+    unless os[:family] == 'redhat' && os[:release].start_with?('8')
+      describe 'time tests' do
+        context 'when set all time parameters' do
+          pp1 = <<-PUPPETCODE
+              class { '::firewall': }
+              firewall { '805 - time':
+                proto              => tcp,
+                dport              => '8080',
+                action             => accept,
+                chain              => 'OUTPUT',
+                date_start         => '2016-01-19T04:17:07',
+                date_stop          => '2038-01-19T04:17:07',
+                time_start         => '6:00',
+                time_stop          => '17:00:00',
+                month_days         => '7',
+                week_days          => 'Tue',
+                kernel_timezone    => true,
+                provider           => 'ip6tables',
+              }
+          PUPPETCODE
+          it 'applies' do
+            apply_manifest(pp1, catch_failures: true)
+            apply_manifest(pp1, catch_changes: do_catch_changes)
+          end
+
+          it 'contains the rule' do
+            shell('ip6tables-save') do |r|
+              expect(r.stdout).to match(
+                %r{-A OUTPUT -p tcp -m multiport --dports 8080 -m time --timestart 06:00:00 --timestop 17:00:00 --monthdays 7 --weekdays Tue --datestart 2016-01-19T04:17:07 --datestop 2038-01-19T04:17:07 --kerneltz -m comment --comment "805 - time" -j ACCEPT}, # rubocop:disable Metrics/LineLength
+              )
+            end
+          end
+        end
+      end
+    end
   end
 
   describe 'unless redhat 5 happy path', unless: (os[:family] == 'redhat' && os[:release].start_with?('5')) do

--- a/spec/acceptance/firewall_attributes_ipv6_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_ipv6_happy_path_spec.rb
@@ -243,20 +243,6 @@ describe 'firewall attribute testing, happy path', unless: (os[:family] == 'redh
           physdev_out        => "eth1",
           physdev_is_bridged => true,
         }
-        firewall { '805 - time':
-          proto              => tcp,
-          dport              => '8080',
-          action             => accept,
-          chain              => 'OUTPUT',
-          date_start         => '2016-01-19T04:17:07',
-          date_stop          => '2038-01-19T04:17:07',
-          time_start         => '6:00',
-          time_stop          => '17:00:00',
-          month_days         => '7',
-          week_days          => 'Tue',
-          kernel_timezone    => true,
-          provider           => 'ip6tables',
-        }
         firewall { '806 - hashlimit_above test ipv6':
           chain                       => 'INPUT',
           provider                    => 'ip6tables',
@@ -373,11 +359,6 @@ describe 'firewall attribute testing, happy path', unless: (os[:family] == 'redh
     end
     it 'tee_gateway is set' do
       expect(result.stdout).to match(%r{-A PREROUTING -m comment --comment "811 - tee_gateway6" -j TEE --gateway 2001:db8::1})
-    end
-    it 'when set all time parameters' do
-      expect(result.stdout).to match(
-        %r{-A OUTPUT -p tcp -m multiport --dports 8080 -m time --timestart 06:00:00 --timestop 17:00:00 --monthdays 7 --weekdays Tue --datestart 2016-01-19T04:17:07 --datestop 2038-01-19T04:17:07 --kerneltz -m comment --comment "805 - time" -j ACCEPT}, # rubocop:disable Metrics/LineLength
-      )
     end
     it 'hashlimit_above is set' do
       regex_array = [%r{-A INPUT}, %r{-p tcp}, %r{--hashlimit-above 526\/sec}, %r{--hashlimit-mode srcip,dstip},


### PR DESCRIPTION
RedHat 8 iptables uses an nftables backend. The `time` match extension
does not appear to be supported. As such, I have moved the test into
exceptions spec.

https://wiki.nftables.org/wiki-nftables/index.php/Supported_features_compared_to_xtables#time