### PR TITLE
Avoid errors on windows nodes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@ class firewall (
       }
       contain "${title}::linux"
     }
-    'FreeBSD': {
+    'FreeBSD', 'windows': {
     }
     default: {
       fail("${title}: Kernel '${::kernel}' is not currently supported")


### PR DESCRIPTION
This change allows puppet agents on windows to include this module without failing.