### PR TITLE
Fix parsing iptables rules with hyphen in comments

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -419,7 +419,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     if values =~ %r{-m comment --comment}
       ind = values.index('-m comment --comment')
       comments = values.scan(%r{-m comment --comment "((?:\\"|[^"])*)"})
-      comments += values.scan(%r{-m comment --comment ([^"]+?)\b})
+      comments += values.scan(%r{-m comment --comment ([^"\s]+)\b})
       values = values.gsub(%r{-m comment --comment (".*?[^\\"]"|[^ ].*)( |$)}, '')
       values = values.gsub(%r{-m comment --comment ([^"].*?)[ $]}, '')
       values.insert(ind, "-m comment --comment \"#{comments.join(';')}\" ")

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -254,6 +254,13 @@ ARGS_TO_HASH = {
       name: '9000 comment_without_quotes',
     },
   },
+  'comments_without_quotes' => {
+    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment 100-comment_without-quotes',
+    table: 'filter',
+    params: {
+      name: '100-comment_without-quotes',
+    },
+  },
   'string_escape_sequences' => {
     line: '-A INPUT -m comment --comment "000 parse escaped \\"s, \\"s, \\\'s, \\\'s, \\\\s and \\\\s"',
     table: 'filter',


### PR DESCRIPTION
Fix parsing rules which have comments including a hyphen mark and no space character.
Example: 101-a-b-c.