### PR TITLE
pdksync - FM-8499 - remove ubuntu14 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -64,7 +64,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "16.04",
         "18.04"
       ]

--- a/provision.yaml
+++ b/provision.yaml
@@ -4,7 +4,7 @@ default:
   images: ['waffleimage/centos7']
 waffle_deb:
   provisioner: docker_exp
-  images: ['waffleimage/debian8', 'waffleimage/debian9', 'waffleimage/ubuntu14.04', 'waffleimage/ubuntu16.04', 'waffleimage/ubuntu18.04']
+  images: ['waffleimage/debian8', 'waffleimage/debian9', 'waffleimage/ubuntu16.04', 'waffleimage/ubuntu18.04']
 waffle_el:
   provisioner: docker
   images: ['waffleimage/centos7']
@@ -13,4 +13,4 @@ vagrant:
   images: ['centos/7', 'generic/ubuntu1804']
 release_checks:
   provisioner: vmpooler
-  images: ['redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'oracle-6-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'sles-11-x86_64', 'sles-12-x86_64', 'sles-15-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64']
+  images: ['redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'oracle-6-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'sles-11-x86_64', 'sles-12-x86_64', 'sles-15-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64']


### PR DESCRIPTION
FM-8499 - remove ubuntu14 support
pdk version: `1.14.0` 
