### PR TITLE
Change - Avoid puppet failures on windows nodes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@ class firewall (
       }
       contain "${title}::linux"
     }
-    'FreeBSD': {
+    'FreeBSD', 'windows': {
     }
     default: {
       fail("${title}: Kernel '${::kernel}' is not currently supported")


### PR DESCRIPTION

![firewall_error](https://user-images.githubusercontent.com/18019703/68690832-aefbba00-0540-11ea-8990-2b91666ed631.PNG)
This module will cause puppet agent runs to fail when it is included
on a windows node.  Updated manifest to do nothing when running on
a windows client.