### PR TITLE
Add support for Debian Unstable

### DIFF
--- a/lib/facter/iptables_persistent_version.rb
+++ b/lib/facter/iptables_persistent_version.rb
@@ -6,7 +6,8 @@ Facter.add(:iptables_persistent_version) do
     os = Facter.value(:operatingsystem)
     os_release = Facter.value(:operatingsystemrelease)
     cmd = if (os == 'Debian' && (Puppet::Util::Package.versioncmp(os_release, '8.0') >= 0)) ||
-             (os == 'Ubuntu' && (Puppet::Util::Package.versioncmp(os_release, '14.10') >= 0))
+             (os == 'Ubuntu' && (Puppet::Util::Package.versioncmp(os_release, '14.10') >= 0)) ||
+             (os == 'Debian' && (Puppet::Util::Package.versioncmp(os_release, 'unstable') >= 0))
             "dpkg-query -Wf '${Version}' netfilter-persistent 2>/dev/null"
           else
             "dpkg-query -Wf '${Version}' iptables-persistent 2>/dev/null"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,10 @@ class firewall::params {
       $service_name_v6 = undef
       case $::operatingsystem {
         'Debian': {
-          if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
+          if versioncmp($::operatingsystemrelease, 'unstable') >= 0 {
+            $service_name = 'netfilter-persistent'
+            $package_name = 'netfilter-persistent'
+          } elsif versioncmp($::operatingsystemrelease, '8.0') >= 0 {
             $service_name = 'netfilter-persistent'
             $package_name = 'iptables-persistent'
           } else {

--- a/spec/unit/classes/firewall_linux_debian_spec.rb
+++ b/spec/unit/classes/firewall_linux_debian_spec.rb
@@ -80,4 +80,67 @@ describe 'firewall::linux::debian', type: :class do
       )
     }
   end
+
+  context 'with Debian 10' do
+    let(:facts) do
+      {
+        osfamily: 'Debian',
+        operatingsystem: 'Debian',
+        operatingsystemrelease: '10.0',
+      }
+    end
+
+    it {
+      is_expected.to contain_package('iptables-persistent').with(
+        ensure: 'present',
+      )
+    }
+    it {
+      is_expected.to contain_service('netfilter-persistent').with(
+        ensure: nil,
+        enable: 'true',
+        require: 'Package[iptables-persistent]',
+      )
+    }
+  end
+
+  context 'with Debian 10, enable => false' do
+    let(:facts) do
+      {
+        osfamily: 'Debian',
+        operatingsystem: 'Debian',
+        operatingsystemrelease: '10',
+      }
+    end
+    let(:params) { { enable: 'false' } }
+
+    it {
+      is_expected.to contain_service('netfilter-persistent').with(
+        enable: 'false',
+      )
+    }
+  end
+
+  context 'with Debian unstable' do
+    let(:facts) do
+      {
+        osfamily: 'Debian',
+        operatingsystem: 'Debian',
+        operatingsystemrelease: 'unstable',
+      }
+    end
+
+    it {
+      is_expected.to contain_package('netfilter-persistent').with(
+        ensure: 'present',
+      )
+    }
+    it {
+      is_expected.to contain_service('netfilter-persistent').with(
+        ensure: nil,
+        enable: 'true',
+        require: 'Package[netfilter-persistent]',
+      )
+    }
+  end
 end


### PR DESCRIPTION
Replacement PR for https://github.com/puppetlabs/puppetlabs-firewall/pull/805

 - Added operatingsystemrelease unstable with netfilter service and package
 - Extended rspec tests for Debian