### PR TITLE
Add u32 to recognized modules

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -150,6 +150,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     tosource: '--to-source',
     to: '--to',
     uid: '--uid-owner',
+    u32: ['-m u32 --u32', '--u32'],
     physdev_in: '--physdev-in',
     physdev_out: '--physdev-out',
     physdev_is_bridged: '--physdev-is-bridged',

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -421,6 +421,14 @@ ARGS_TO_HASH = {
       src_type: ['! LOCAL --limit-iface-out', 'LOCAL'],
     },
   },
+  'u32' => {
+    line: '-A cali-fw-cali08818b3e1e0 -m u32 --u32 "0x0>>0x16&0x3c@0xc>>0x8=0x1000"',
+    table: 'filter',
+    params: {
+      chain: 'cali-fw-cali08818b3e1e0',
+      name:  '9000 fff92a2f7e1c5e95f852fdd7e4bd103785db4ae08bc24edd8ed530403bc16e45',
+    },
+  },
   'iniface_1_negated' => {
     line: '-A INPUT ! -i eth0 -j DROP -m comment --comment "060 iniface"',
     table: 'filter',


### PR DESCRIPTION
Similarly to https://tickets.puppetlabs.com/browse/MODULES-6379, we are getting warnings for u32:

```
Warning: Puppet::Type::Firewall::ProviderIptables: Skipping unparsable iptables rule: keys (5) and values (9) count mismatch on line: -A cali-fw-cali08818b3e1e0 -p udp -m comment --comment "cali:mpXsk9dUM2JyVL-L" -m comment --comment "Drop VXLAN encapped packets originating in pods" -m multiport --dports 4789 -m u32 --u32 "0x0>>0x16&0x3c@0xc>>0x8=0x1000" -j DROP
```

This fixes that