### PR TITLE
MODULES-10522: Add support for the --condition parameter

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -2,6 +2,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
   @doc = 'Ip6tables type provider'
 
   has_feature :iptables
+  has_feature :condition
   has_feature :connection_limiting
   has_feature :conntrack
   has_feature :hop_limiting
@@ -69,6 +70,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     burst: '--limit-burst',
     checksum_fill: '--checksum-fill',
     clamp_mss_to_pmtu: '--clamp-mss-to-pmtu',
+    condition: '--condition',
     connlimit_above: '-m connlimit --connlimit-above',
     connlimit_mask: '--connlimit-mask',
     connmark: '-m connmark --mark',
@@ -220,6 +222,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     addrtype: [:src_type, :dst_type],
     iprange: [:src_range, :dst_range],
     owner: [:uid, :gid],
+    condition: [:condition],
     conntrack: [:ctstate, :ctproto, :ctorigsrc, :ctorigdst, :ctreplsrc, :ctrepldst,
                 :ctorigsrcport, :ctorigdstport, :ctreplsrcport, :ctrepldstport, :ctstatus, :ctexpire, :ctdir],
     time: [:time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone],
@@ -277,5 +280,5 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
                     :set_mark, :match_mark, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
                     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
                     :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask, :hashlimit_htable_size,
-                    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :zone, :name]
+                    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :zone, :condition, :name]
 end

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -7,6 +7,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
   @doc = 'Iptables type provider'
 
   has_feature :iptables
+  has_feature :condition
   has_feature :connection_limiting
   has_feature :conntrack
   has_feature :rate_limiting
@@ -65,6 +66,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     burst: '--limit-burst',
     checksum_fill: '--checksum-fill',
     clamp_mss_to_pmtu: '--clamp-mss-to-pmtu',
+    condition: '--condition',
     connlimit_above: '-m connlimit --connlimit-above',
     connlimit_mask: '--connlimit-mask',
     connmark: '-m connmark --mark',
@@ -227,6 +229,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     addrtype: [:src_type, :dst_type],
     iprange: [:src_range, :dst_range],
     owner: [:uid, :gid],
+    condition: [:condition],
     conntrack: [:ctstate, :ctproto, :ctorigsrc, :ctorigdst, :ctreplsrc, :ctrepldst,
                 :ctorigsrcport, :ctorigdstport, :ctreplsrcport, :ctrepldstport, :ctstatus, :ctexpire, :ctdir],
     time: [:time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone],
@@ -323,7 +326,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
     :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask, :hashlimit_htable_size,
-    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :name
+    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :condition, :name
   ]
 
   def insert
@@ -623,6 +626,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     # Invert any rules that are prefixed with a '!'
     [
       :connmark,
+      :condition,
       :ctstate,
       :ctproto,
       :ctorigsrc,

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -54,6 +54,8 @@ Puppet::Type.newtype(:firewall) do
 
       * clusterip: Configure a simple cluster of nodes that share a certain IP and MAC address without an explicit load balancer in front of them.
 
+      * condition: Match if a specific condition variable is (un)set (requires xtables-addons)
+
       * connection_limiting: Connection limiting features.
 
       * conntrack: Connection tracking features.
@@ -136,6 +138,7 @@ Puppet::Type.newtype(:firewall) do
   PUPPETCODE
 
   feature :connection_limiting, 'Connection limiting features.'
+  feature :condition, 'Match if a specific condition variable is (un)set.'
   feature :conntrack, 'Connection tracking features.'
   feature :hop_limiting, 'Hop limiting features.'
   feature :rate_limiting, 'Rate limiting features.'
@@ -2155,6 +2158,19 @@ Puppet::Type.newtype(:firewall) do
     desc <<-PUPPETCODE
       Assign this packet to zone id and only have lookups done in that zone.
     PUPPETCODE
+  end
+
+  newproperty(:condition, required_features: :condition) do
+    desc <<-PUPPETCODE
+      Match on boolean value (0/1) stored in /proc/net/nf_condition/name.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          Condition must be a string.
+        PUPPETCODE
+      end
+    end
   end
 
   autorequire(:firewallchain) do

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -823,6 +823,13 @@ describe firewall do # rubocop:disable RSpec/MultipleDescribes
     end
   end
 
+  describe ':condition' do
+    it 'accepts value as a string' do
+      resource[:condition] = 'somefile'
+      expect(resource[:condition]).to eq('somefile')
+    end
+  end
+
   describe 'autorequire packages' do
     [:iptables, :ip6tables].each do |provider|
       it "provider #{provider} should autorequire package iptables" do


### PR DESCRIPTION
This allows Puppet to control the entire iptables/ip6tables ruleset while at the
same time allowing some rules to be disabled or enabled outside of Puppet based
on content of files under /proc/net/nf_condition. This feature depends on
xtables-addons.