### PR TITLE
Add random_fully and rpfilter support

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
   has_feature :queue_num
   has_feature :queue_bypass
   has_feature :ct_target
+  has_feature :rpfilter
 
   optional_commands(ip6tables: 'ip6tables',
                     ip6tables_save: 'ip6tables-save')
@@ -130,6 +131,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     reject: '--reject-with',
     rhitcount: '--hitcount',
     rname: '--name',
+    rpfilter: '-m rpfilter',
     rseconds: '--seconds',
     rsource: '--rsource',
     rttl: '--rttl',
@@ -200,6 +202,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     :rsource,
     :rdest,
     :reap,
+    :rpfilter,
     :rttl,
     :socket,
     :physdev_is_bridged,
@@ -284,5 +287,5 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
                     :set_mark, :match_mark, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
                     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
                     :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask, :hashlimit_htable_size,
-                    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :zone, :helper, :name]
+                    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :zone, :helper, :rpfilter, :name]
 end

--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -49,6 +49,12 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
                 '--set-xmark'
               end
 
+  kernelversion = Facter.value('kernelversion')
+  if (kernelversion && Puppet::Util::Package.versioncmp(kernelversion, '3.13') >= 0) &&
+     (ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.6.2') >= 0)
+    has_feature :random_fully
+  end
+
   def initialize(*args)
     ip6tables_version = Facter.value('ip6tables_version')
     raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if ip6tables_version && ip6tables_version.match(%r{1\.3\.\d})

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -45,6 +45,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
   has_feature :queue_bypass
   has_feature :ipvs
   has_feature :ct_target
+  has_feature :rpfilter
 
   optional_commands(iptables: 'iptables',
                     iptables_save: 'iptables-save')
@@ -129,6 +130,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     reject: '--reject-with',
     rhitcount: '--hitcount',
     rname: '--name',
+    rpfilter: '-m rpfilter',
     rseconds: '--seconds',
     rsource: '--rsource',
     rttl: '--rttl',
@@ -332,7 +334,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
     :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask, :hashlimit_htable_size,
-    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :helper, :name
+    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :helper, :rpfilter, :name
   ]
 
   def insert

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1639,6 +1639,17 @@ Puppet::Type.newtype(:firewall) do
     newvalues(:true, :false)
   end
 
+  newproperty(:rpfilter, required_features: :rpfilter) do
+    desc <<-PUPPETCODE
+      Enable the rpfilter module.
+    PUPPETCODE
+
+    newvalues(:loose, :validmark, :'accept-local', :invert)
+    munge do |value|
+      _value = '--' + value
+    end
+  end
+
   newproperty(:socket, required_features: :socket) do
     desc <<-PUPPETCODE
       If true, matches if an open socket can be found by doing a coket lookup

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -133,6 +133,8 @@ Puppet::Type.newtype(:firewall) do
       * ipvs: The ability to match IP Virtual Server packets.
 
       * ct_target: The ability to set connection tracking parameters for a packet or its associated connection.
+
+      * random_fully: The ability to use --random-fully flag.
   PUPPETCODE
 
   feature :connection_limiting, 'Connection limiting features.'
@@ -179,6 +181,7 @@ Puppet::Type.newtype(:firewall) do
   feature :bpf, 'Berkeley Paket Filter feature'
   feature :ipvs, 'Packet belongs to an IP Virtual Server connection'
   feature :ct_target, 'The ability to set connection tracking parameters for a packet or its associated connection'
+  feature :random_fully, 'The ability to use --random-fully flag'
   # provider specific features
   feature :iptables, 'The provider provides iptables features.'
 
@@ -719,6 +722,17 @@ Puppet::Type.newtype(:firewall) do
     desc <<-PUPPETCODE
       For NETMAP this will replace the destination IP
     PUPPETCODE
+  end
+
+  newproperty(:random_fully, required_features: :random_fully) do
+    desc <<-PUPPETCODE
+      When using a jump value of "MASQUERADE", "DNAT", "REDIRECT", or "SNAT"
+      this boolean will enable fully randomized port mapping.
+
+      **NOTE** Requires Kernel >= 3.13 and iptables >= 1.6.2
+    PUPPETCODE
+
+    newvalues(:true, :false)
   end
 
   newproperty(:random, required_features: :dnat) do

--- a/spec/acceptance/firewall_attributes_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_happy_path_spec.rb
@@ -322,6 +322,12 @@ describe 'firewall attribute testing, happy path' do
             physdev_out        => "eth1",
             physdev_is_bridged => true,
           }
+          firewall { '900 - set rpfilter':
+            table    => 'raw',
+            chain    => 'PREROUTING',
+            action   => 'accept',
+            rpfilter => 'invert',
+          }
           firewall { '1000 - set_dscp':
             proto     => 'tcp',
             jump      => 'DSCP',


### PR DESCRIPTION
This is the rule from Kubernetes that was breaking the iptables-save parsing:

```
-A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -m mark --mark 0x4000/0x4000 -j MASQUERADE --random-fully
```

This was the full error:

```
Debug: Puppet::Type::Firewall::ProviderIptables: [instances]
Debug: Executing: '/usr/sbin/iptables-save'
Error: /Firewallchain[OUTPUT:filter:IPv4]: Failed to generate additional resources using 'generate': Parser error: random was meant to be a boolean but received value: true-fully.
/opt/puppetlabs/puppet/cache/lib/puppet/provider/firewall/iptables.rb:589:in `block in rule_to_hash'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/firewall/iptables.rb:587:in `each'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/firewall/iptables.rb:587:in `rule_to_hash'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/firewall/iptables.rb:385:in `block in instances'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/firewall/iptables.rb:380:in `each'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/firewall/iptables.rb:380:in `instances'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:1164:in `block in instances'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:1163:in `collect'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:1163:in `instances'
/opt/puppetlabs/puppet/cache/lib/puppet/type/firewallchain.rb:235:in `generate'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction/additional_resource_generator.rb:22:in `generate_additional_resources'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction.rb:96:in `block in evaluate'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction.rb:96:in `each'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction.rb:96:in `evaluate'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:239:in `block (2 levels) in apply'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:519:in `block in thinmark'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:518:in `thinmark'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:238:in `block in apply'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/log.rb:161:in `with_destination'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction/report.rb:146:in `as_logging_destination'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:237:in `apply'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:186:in `block (2 levels) in apply_catalog'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:519:in `block in thinmark'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:518:in `thinmark'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:185:in `block in apply_catalog'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:232:in `block in benchmark'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:231:in `benchmark'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:184:in `apply_catalog'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:366:in `run_internal'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:234:in `block in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:65:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:260:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/configurer.rb:211:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:59:in `block (5 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/2.4.0/timeout.rb:76:in `timeout'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:58:in `block (4 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent/locker.rb:21:in `lock'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:52:in `block (3 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:130:in `with_client'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:49:in `block (2 levels) in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:87:in `run_in_fork'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:48:in `block in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:179:in `controlled_run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/agent.rb:46:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application/agent.rb:372:in `onetime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application/agent.rb:350:in `run_command'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:375:in `block in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:667:in `exit_on_fail'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:375:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:139:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:77:in `execute'
/opt/puppetlabs/puppet/bin/puppet:5:in `<main>'
```