### PR TITLE
Add support for cgroup arg

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1316,6 +1316,10 @@ Assign this packet to zone id and only have lookups done in that zone.
 
 Invoke the nf_conntrack_xxx helper module for this packet.
 
+##### `cgroup`
+
+Matches against the net_cls cgroup ID of the packet.
+
 #### Parameters
 
 The following parameters are available in the `firewall` type.

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -196,6 +196,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     ipvs: '-m ipvs --ipvs',
     zone: '--zone',
     helper: '--helper',
+    cgroup: '-m cgroup --cgroup',
   }
 
   # These are known booleans that do not take a value, but we want to munge
@@ -335,7 +336,8 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
     :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask, :hashlimit_htable_size,
-    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :helper, :rpfilter, :name
+    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :helper, :cgroup,
+    :rpfilter, :name
   ]
 
   def insert

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -2196,6 +2196,12 @@ Puppet::Type.newtype(:firewall) do
     PUPPETCODE
   end
 
+  newproperty(:cgroup) do
+    desc <<-PUPPETCODE
+      Matches against the net_cls cgroup ID of the packet.
+    PUPPETCODE
+  end
+
   autorequire(:firewallchain) do
     reqs = []
     protocol = nil

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -763,6 +763,13 @@ ARGS_TO_HASH = {
     produce_warning: true,
     params: {},
   },
+  'cgroup_matching_1' => {
+    line: '-A INPUT -m cgroup --cgroup "0x100001"',
+    table: 'filter',
+    params: {
+      cgroup: '0x100001',
+    },
+  },
 }.freeze
 
 # This hash is for testing converting a hash to an argument line.


### PR DESCRIPTION
This adds the cgroup matcher, which allows matching packets based on their net_cls cgroup ID.