### PR TITLE
fix parsing of '! --hex-string' from iptables-save

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -449,6 +449,8 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     # --tcp-flags takes two values; we cheat by adding " around it
     # so it behaves like --comment
     values = values.gsub(%r{(!\s+)?--tcp-flags (\S*) (\S*)}, '--tcp-flags "\1\2 \3"')
+    # --hex-string output is in quotes, need to move ! inside quotes
+    values = values.gsub(%r{(!\s+)?--hex-string "(\S*?)"}, '--hex-string "\1\2"')
     # --match-set can have multiple values with weird iptables format
     if values =~ %r{-m set (!\s+)?--match-set}
       values = values.gsub(%r{(!\s+)?--match-set (\S*) (\S*)}, '--match-set \1\2 \3')


### PR DESCRIPTION
iptables-save outputs the value of --hex-string inside quotes, which was
causing quotes inside quotes problems with the value.  This change adds
a special case parser for --hex-string to get the ! inside the quotes
and eliminate the doubled quotation marks