### PR TITLE
Fix problem with parsing rules without quotes

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -465,7 +465,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
       ind = values.index('-m comment --comment')
       comments = values.scan(%r{-m comment --comment "((?:\\"|[^"])*)"})
       comments += values.scan(%r{-m comment --comment ([^"\s]+)\b})
-      values = values.gsub(%r{-m comment --comment (".*?[^\\"]"|[^ ].*)( |$)}, '')
+      values = values.gsub(%r{-m comment --comment (".*?[^\\"]")( |$)}, '')
       values = values.gsub(%r{-m comment --comment ([^"].*?)[ $]}, '')
       values.insert(ind, "-m comment --comment \"#{comments.join(';')}\" ")
     end

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -234,38 +234,43 @@ ARGS_TO_HASH = {
     },
   },
   'comment_string_character_validation' => {
-    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment "000 allow from 192.168.0.1, please"',
+    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment "000 allow from 192.168.0.1, please" -j ACCEPT',
     table: 'filter',
     params: {
       source: '192.168.0.1/32',
+      action: 'accept',
     },
   },
   'multiple_comments' => {
-    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment "000 allow from 192.168.0.1, please" -m comment --comment "another comment"',
+    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment "000 allow from 192.168.0.1, please" -m comment --comment "another comment" -j ACCEPT',
     table: 'filter',
     params: {
       name: '000 allow from 192.168.0.1, please;another comment',
+      action: 'accept',
     },
   },
-  'comments_without_quotes' => {
-    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment comment_without_quotes',
+  'comments_without_quotes_with_underscores' => {
+    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment comment_without_quotes -j ACCEPT',
     table: 'filter',
     params: {
       name: '9000 comment_without_quotes',
+      action: 'accept',
     },
   },
-  'comments_without_quotes' => {
-    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment 100-comment_without-quotes',
+  'comments_without_quotes_with_dashes' => {
+    line: '-A INPUT -s 192.168.0.1/32 -m comment --comment 100-comment_without-quotes -j ACCEPT',
     table: 'filter',
     params: {
       name: '100-comment_without-quotes',
+      action: 'accept',
     },
   },
   'string_escape_sequences' => {
-    line: '-A INPUT -m comment --comment "000 parse escaped \\"s, \\"s, \\\'s, \\\'s, \\\\s and \\\\s"',
+    line: '-A INPUT -m comment --comment "000 parse escaped \\"s, \\"s, \\\'s, \\\'s, \\\\s and \\\\s" -j ACCEPT',
     table: 'filter',
     params: {
       name: '000 parse escaped "s, "s, \'s, \'s, \\s and \\s',
+      action: 'accept',
     },
   },
   'log_level_debug' => {


### PR DESCRIPTION
Hello,

we've been using Puppet quite heavily at Opera. Recently I started rolling out fresh version of firewall module on our hosts and noticed a lot of corrective changes being applied, e.g.:
```
Notice: /Stage[main]/Osp_firewall/Firewall[099_a_long_example_rule_with_underscores]/action: current_value , should be 'accept' (noop) (corrective)
```

I think I traced the problem to regex in iptables provider being too greedy and removing suffix with jump target instead of just the name of the rule. I believe the issue is best visible [via regexr](https://regexr.com/59m2h).

Cheers,