### PR TITLE
(IAC-1025) Fix spec test helper method

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -20,7 +20,11 @@ end
 def install_iptables
   run_shell('iptables -V')
 rescue
-  run_shell('apt-get install iptables -y')
+  if os[:family] == 'redhat'
+    run_shell('yum install iptables-services -y')
+  else
+    run_shell('apt-get install iptables -y')
+  end
 end
 
 def iptables_version


### PR DESCRIPTION
Tests failing on RHEL systems as the `install_iptables` method
always assumed it was running against Debian / Ubuntu.