### PR TITLE
Fix extra quotes in firewall string matching

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -2062,10 +2062,6 @@ Puppet::Type.newtype(:firewall) do
       String matching feature. Matches the packet against the pattern
       given as an argument.
     PUPPETCODE
-
-    munge do |value|
-      _value = "'" + value + "'"
-    end
   end
 
   newproperty(:string_hex) do

--- a/spec/fixtures/iptables/conversion_hash.rb
+++ b/spec/fixtures/iptables/conversion_hash.rb
@@ -1390,7 +1390,7 @@ HASH_TO_ARGS = {
       table: 'filter',
       string: 'GET /index.html',
     },
-    args: ['-t', :filter, '-p', :tcp, '-m', 'string', '--string', "'GET /index.html'", '-m', 'comment', '--comment', '000 string_matching'],
+    args: ['-t', :filter, '-p', :tcp, '-m', 'string', '--string', "GET /index.html", '-m', 'comment', '--comment', '000 string_matching'],
   },
   'string_matching_2' => {
     params: {
@@ -1399,7 +1399,7 @@ HASH_TO_ARGS = {
       string: 'GET /index.html',
       string_algo: 'bm',
     },
-    args: ['-t', :filter, '-p', :tcp, '-m', 'string', '--string', "'GET /index.html'", '--algo', :bm, '-m', 'comment', '--comment', '000 string_matching'],
+    args: ['-t', :filter, '-p', :tcp, '-m', 'string', '--string', "GET /index.html", '--algo', :bm, '-m', 'comment', '--comment', '000 string_matching'],
   },
   'string_matching_3' => {
     params: {
@@ -1409,7 +1409,7 @@ HASH_TO_ARGS = {
       string_from: '1',
       string_to: '65535',
     },
-    args: ['-t', :filter, '-p', :tcp, '-m', 'string', '--string', "'GET /index.html'", '--from', '1', '--to', '65535', '-m', 'comment', '--comment', '000 string_matching'],
+    args: ['-t', :filter, '-p', :tcp, '-m', 'string', '--string', "GET /index.html", '--from', '1', '--to', '65535', '-m', 'comment', '--comment', '000 string_matching'],
   },
   'nfqueue_jump1' => {
     params: {


### PR DESCRIPTION
As reported by Steve Traylon[1] and @patricknelson[2], the munging adds extra quotes to the string.
This breaks the string matching in iptables, as it looks for literal single quotes in the match.

Removing the munging fixes this.

[1] https://tickets.puppetlabs.com/browse/MODULES-3454?focusedCommentId=686988&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-686988
[2] https://github.com/puppetlabs/puppetlabs-firewall/commit/3655c6bd33d662a3813c2f66cd0bc5889c68c2c2#diff-379160b60a9bdf297b92a51d20efd8c3R1426