### PR TITLE
Update firewall.rb

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -549,7 +549,7 @@ Puppet::Type.newtype(:firewall) do
       The specific protocol to match for this rule.
     PUPPETCODE
 
-    newvalues(*[:ip, :tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :cbt, :sctp, :pim, :all].map { |proto|
+    newvalues(*[:ip, :tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :carp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :cbt, :sctp, :pim, :all].map { |proto|
       [proto, "! #{proto}".to_sym]
     }.flatten)
     defaultto 'tcp'


### PR DESCRIPTION
On Gentoo using 'vrrp' sets the proto to 112 but when puppet runs it interprets 112 as 'carp' which it then corrects to 'vrrp' which is still 112. So it redoes the rule every time puppet runs. Adding carp here allows carp to be set as a valid option which removes the loop.