### PR TITLE
Fix build failures caused by safe operator syntax

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
 
   def initialize(*args)
     ip6tables_version = Facter.value('ip6tables_version')
-    raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if ip6tables_version&.match(%r{1\.3\.\d})
+    raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if ip6tables_version && ip6tables_version.match(%r{1\.3\.\d})
     super
   end
 

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -651,7 +651,9 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
         elem.tr(':', '-')
       end
     end
-    hash[:length]&.tr!(':', '-')
+    if hash[:length]
+      hash[:length].tr!(':', '-')
+    end
 
     # Invert any rules that are prefixed with a '!'
     [
@@ -682,7 +684,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
       :src_range,
       :state,
     ].each do |prop|
-      if hash[prop]&.is_a?(Array)
+      if hash[prop] && hash[prop].is_a?(Array)
         # find if any are negated, then negate all if so
         should_negate = hash[prop].index do |value|
           value.match(%r{^(!)\s+})


### PR DESCRIPTION
The changes from commit 7efed060 cause build failures when running unit tests on CentOS 7.

For example, here is a snippet from our jenkins build logs.

```
02:39:10       Puppet::PreformattedError:
02:39:10         Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/firewall: Could not autoload puppet/provider/firewall/ip6tables: /var/lib/jenkins/workspace/mdct-vsftpd/spec/fixtures/modules/firewall/lib/puppet/provider/firewall/ip6tables.rb:71: syntax error, unexpected '.'
02:39:10         ...ptables' if ip6tables_version&.match(%r{1\.3\.\d})
02:39:10         ...                               ^ (file: /var/lib/jenkins/workspace/mdct-vsftpd/spec/fixtures/modules/vsftpd/manifests/init.pp, line: 68, column: 9) on node jenkins.example.com
```