### PR TITLE
MODULES-10693: Add Hmark support (Draft, help wanted)

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -24,6 +24,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
   has_feature :log_tcp_options
   has_feature :log_ip_options
   has_feature :mark
+  has_feature :hmark
   has_feature :mss
   has_feature :nflog_group
   has_feature :nflog_prefix
@@ -208,6 +209,16 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     zone: '--zone',
     helper: '--helper',
     notrack: '--notrack',
+    hmark_tuple: '--hmark-tuple',
+    hmark_mod: '--hmark-mod',
+    hmark_offset: '--hmark-offset',
+    hmark_src_prefix: '--hmark-src-prefix',
+    hmark_dst_prefix: '--hmark-dst-prefix',
+    hmark_sport_mask: '--hmark-sport-mask',
+    hmark_dport_mask: '--hmark-dport-mask',
+    hmark_spi_mask: '--hmark-spi-mask',
+    hmark_proto_mask: '--hmark-proto-mask',
+    hmark_rnd: '--hmark-rnd',
   }
 
   # These are known booleans that do not take a value, but we want to munge
@@ -313,5 +324,8 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
                     :set_mark, :match_mark, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
                     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
                     :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask, :hashlimit_htable_size,
-                    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :zone, :helper, :rpfilter, :condition, :name, :notrack]
+                    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :zone, :helper, :rpfilter, :condition, :name, :notrack,
+                    :hmark_tuple, :hmark_mod, :hmark_offset, :hmark_src_prefix, :hmark_dst_prefix, :hmark_sport_mask,
+                    :hmark_dport_mask, :hmark_spi_mask, :hmark_proto_mask, :hmark_rnd
+                    ]
 end

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -29,6 +29,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
   has_feature :log_tcp_options
   has_feature :log_ip_options
   has_feature :mark
+  has_feature :hmark
   has_feature :mss
   has_feature :nflog_group
   has_feature :nflog_prefix
@@ -209,6 +210,16 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     helper: '--helper',
     cgroup: '-m cgroup --cgroup',
     notrack: '--notrack',
+    hmark_tuple: '--hmark-tuple',
+    hmark_mod: '--hmark-mod',
+    hmark_offset: '--hmark-offset',
+    hmark_src_prefix: '--hmark-src-prefix',
+    hmark_dst_prefix: '--hmark-dst-prefix',
+    hmark_sport_mask: '--hmark-sport-mask',
+    hmark_dport_mask: '--hmark-dport-mask',
+    hmark_spi_mask: '--hmark-spi-mask',
+    hmark_proto_mask: '--hmark-proto-mask',
+    hmark_rnd: '--hmark-rnd',
   }
 
   # These are known booleans that do not take a value, but we want to munge
@@ -353,7 +364,9 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
     :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,
     :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask, :hashlimit_htable_size,
-    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :helper, :cgroup, :rpfilter, :condition, :name, :notrack
+    :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval, :bytecode, :ipvs, :zone, :helper, :cgroup, :rpfilter, :condition, :name, :notrack,
+    :hmark_tuple, :hmark_mod, :hmark_offset, :hmark_src_prefix, :hmark_dst_prefix, :hmark_sport_mask,
+    :hmark_dport_mask, :hmark_spi_mask, :hmark_proto_mask, :hmark_rnd
   ]
 
   def insert

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -170,6 +170,7 @@ Puppet::Type.newtype(:firewall) do
   feature :log_tcp_options, 'Add TCP packet header to log messages'
   feature :log_ip_options, 'Add IP/IPv6 packet header to log messages'
   feature :mark, 'Match or Set the netfilter mark value associated with the packet'
+  feature :hmark, 'Mark the packets depending on certain criteria'
   feature :mss, 'Match a given TCP MSS value or range.'
   feature :tcp_flags, 'The ability to match on particular TCP flag settings'
   feature :pkttype, 'Match a packet type'
@@ -1314,6 +1315,136 @@ Puppet::Type.newtype(:firewall) do
       value = mark
 
       value
+    end
+  end
+
+  newproperty(:hmark_tuple, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      The tuple to match hmark on.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_tuple must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_mod, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      The hmark modulus for hash calculation.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_mode must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_offset, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Offset to start marks from.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_offset must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_src_prefix, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Hmark source address mask (cidr).
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_src_prefix must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_dst_prefix, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Hmark destination address mask (cidr).
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_dst_prefix must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_sport_mask, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Hmark 16 bit source port mask in hexadecimal.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_sport_mask must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_dport_mask, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Hmark 16 bit destination port mask in hexadecimal.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_dport_mask must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_spi_mask, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Hmark 32 bit field with spi mask.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_spi_mask must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_proto_mask, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Hmark 8 bit field with layer 4 protocol number.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_proto_mask must be a string.
+        PUPPETCODE
+      end
+    end
+  end
+
+  newproperty(:hmark_rnd, required_features: :hmark) do
+    desc <<-PUPPETCODE
+      Hmark 32 bit random custom value to feed hash calculation.
+    PUPPETCODE
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, <<-PUPPETCODE
+          hmark_rnd must be a string.
+        PUPPETCODE
+      end
     end
   end
 
@@ -2506,5 +2637,14 @@ Puppet::Type.newtype(:firewall) do
         raise 'Parameter jump => CT only applies to table => raw'
       end
     end
+
+    if value(:hmark_tuple) || value(:hmark_mod) || value(:hmark_offset) || value(:hmark_src_prefix) ||
+       value(:hmark_dst_prefix) || value(:hmark_sport_mask) || value(:hmark_dport_mask) ||
+       value(:hmark_spi_mask) || value(:hmark_proto_mask) || value(:hmark_rnd) == :true
+      unless value(:jump).to_s == 'HMARK'
+        raise 'HMARK parameters require jump => HMARK'
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi,

this is a first draft/attempt to add support for the HMARK iptables extension, as requested in MODULES-10693.

Can somebody help me how to properly define the order of resources in ```@resource_list```? After this, I can add proper testing cases and remove the draft flag.

Thank you!