### PR TITLE
sles-15: mac_source is downcased by iptables

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1850,6 +1850,13 @@ Puppet::Type.newtype(:firewall) do
       MAC Source
     PUPPETCODE
     newvalues(%r{^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$}i)
+    facter_os_name = Facter.fact(:os).value['name'].downcase
+    facter_os_release = Facter.fact(:os).value['release']['major'].to_i
+    if facter_os_name == 'sles' && facter_os_release == 15
+      munge do |value|
+        _value = value.downcase
+      end
+    end
   end
 
   newproperty(:physdev_in, required_features: :iptables) do

--- a/spec/acceptance/firewall_attributes_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_exceptions_spec.rb
@@ -337,14 +337,14 @@ describe 'firewall basics', docker: true do
           }
       PUPPETCODE
       it 'applies' do
-        apply_manifest(pp88, catch_failures: true)
+        idempotent_apply(pp88)
       end
       it 'contains the rule' do
         run_shell('iptables-save') do |r|
           if os[:family] == 'redhat' && os[:release].start_with?('5')
             expect(r.stdout).to match(%r{-A INPUT -s 10.1.5.28 -p tcp -m mac --mac-source 0A:1B:3C:4D:5E:6F -m comment --comment "610 - test"})
           else
-            expect(r.stdout).to match(%r{-A INPUT -s 10.1.5.28\/(32|255\.255\.255\.255) -p tcp -m mac --mac-source 0A:1B:3C:4D:5E:6F -m comment --comment "610 - test"})
+            expect(r.stdout).to match(%r{-A INPUT -s 10.1.5.28\/(32|255\.255\.255\.255) -p tcp -m mac --mac-source 0(a|A):1(b|B):3(c|C):4(d|D):5(e|E):6(f|F) -m comment --comment "610 - test"})
           end
         end
       end


### PR DESCRIPTION
It looks that `mac_source` parameter cannot be applied idempotently on `sles-15` iptables downcase the value.
For example: `'0A:1B:3C:4D:5E:6F' --> '0a:1b:3c:4d:5e:6f'`. And puppet triggers this as `Properties changed - updating ruled`
```shell
Notice: Compiled catalog for litmus-0bf65b80828b158e.c.ia-content.internal in environment production in 0.08 seconds
Notice: /Stage[main]/Main/Firewall[610 - test]/mac_source: mac_source changed '0a:1b:3c:4d:5e:6f' to '0A:1B:3C:4D:5E:6F'
Notice: Firewall[610 - test](provider=iptables): Properties changed - updating rule
Notice: Applied catalog in 0.14 seconds
```