### PR TITLE
(MODULES-11138) - Fix mac_source Facter.fact().value() issue with Facter 3

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1850,8 +1850,8 @@ Puppet::Type.newtype(:firewall) do
       MAC Source
     PUPPETCODE
     newvalues(%r{^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$}i)
-    facter_os_name = Facter.fact(:os).value['name'].downcase
-    facter_os_release = Facter.fact(:os).value['release']['major'].to_i
+    facter_os_name = Facter.value(:operatingsystem).downcase
+    facter_os_release = Facter.value(:operatingsystemrelease).to_i
     if facter_os_name == 'sles' && facter_os_release == 15
       munge do |value|
         _value = value.downcase

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1850,8 +1850,8 @@ Puppet::Type.newtype(:firewall) do
       MAC Source
     PUPPETCODE
     newvalues(%r{^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$}i)
-    facter_os_name = Facter.value(:operatingsystem).downcase
-    facter_os_release = Facter.value(:operatingsystemrelease).to_i
+    facter_os_name = Facter.value(:os)['name'].downcase
+    facter_os_release = Facter.value(:os)['release']['major'].to_i
     if facter_os_name == 'sles' && facter_os_release == 15
       munge do |value|
         _value = value.downcase


### PR DESCRIPTION
According to the firewall module [HISTORY.md](https://github.com/puppetlabs/puppetlabs-firewall/blob/main/HISTORY.md#2015-07-28---supported-release-170) `Facter.fact().value()` is not supported by `Facter 3` - `Replace Facter.fact().value() calls with Facter.value() to support Facter 3`
I added by mistake trying to repair our nightly CI. This PR should repair users problems created by the previous commit and not block our nightly CI

kind regards,
@adrianiurca 