### PR TITLE
Detect AlmaLinux as RedHat

### DIFF
--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -172,7 +172,7 @@ module Puppet::Util::Firewall
     # Basic normalisation for older Facter
     os_key = Facter.value(:osfamily)
     os_key ||= case Facter.value(:operatingsystem)
-               when 'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer', 'VirtuozzoLinux', 'Rocky'
+               when 'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer', 'VirtuozzoLinux', 'Rocky', 'AlmaLinux'
                  'RedHat'
                when 'Debian', 'Ubuntu'
                  'Debian'

--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -57,7 +57,7 @@ class firewall::linux (
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos',
     'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer',
-    'VirtuozzoLinux', 'Rocky': {
+    'VirtuozzoLinux', 'Rocky', 'AlmaLinux': {
       class { "${title}::redhat":
         ensure          => $ensure,
         ensure_v6       => $_ensure_v6,


### PR DESCRIPTION
AlmaLinux seems to be missing from the list of RedHat distros.

Though to be honest, the case statement in linux.pp could probably just check for `$osfamily == "RedHat"` instead of listing all of the options