### PR TITLE
Fix rpfilter parameter

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -46,7 +46,6 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
   has_feature :queue_num
   has_feature :queue_bypass
   has_feature :ct_target
-  has_feature :rpfilter
 
   optional_commands(ip6tables: 'ip6tables',
                     ip6tables_save: 'ip6tables-save')
@@ -64,6 +63,11 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
   if (kernelversion && Puppet::Util::Package.versioncmp(kernelversion, '3.13') >= 0) &&
      (ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.6.2') >= 0)
     has_feature :random_fully
+  end
+
+  if (kernelversion && Puppet::Util::Package.versioncmp(kernelversion, '3.3') >= 0) &&
+    (ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.4.13') >= 0)
+    has_feature :rpfilter
   end
 
   def initialize(*args)

--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -66,7 +66,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
   end
 
   if (kernelversion && Puppet::Util::Package.versioncmp(kernelversion, '3.3') >= 0) &&
-    (ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.4.13') >= 0)
+     (ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.4.13') >= 0)
     has_feature :rpfilter
   end
 

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -76,7 +76,6 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     has_feature :rpfilter
   end
 
-
   @protocol = 'IPv4'
 
   @resource_map = {

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -51,7 +51,6 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
   has_feature :queue_bypass
   has_feature :ipvs
   has_feature :ct_target
-  has_feature :rpfilter
 
   optional_commands(iptables: 'iptables',
                     iptables_save: 'iptables-save')
@@ -71,6 +70,12 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
      (iptables_version && Puppet::Util::Package.versioncmp(iptables_version, '1.6.2') >= 0)
     has_feature :random_fully
   end
+
+  if (kernelversion && Puppet::Util::Package.versioncmp(kernelversion, '3.3') >= 0) &&
+     (iptables_version && Puppet::Util::Package.versioncmp(iptables_version, '1.4.13') >= 0)
+    has_feature :rpfilter
+  end
+
 
   @protocol = 'IPv4'
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -173,6 +173,7 @@ Puppet::Type.newtype(:firewall) do
   feature :mss, 'Match a given TCP MSS value or range.'
   feature :tcp_flags, 'The ability to match on particular TCP flag settings'
   feature :pkttype, 'Match a packet type'
+  feature :rpfilter, 'Perform reverse-path filtering'
   feature :socket, 'Match open sockets'
   feature :isfragment, 'Match fragments'
   feature :address_type, 'The ability match on source or destination address type'


### PR DESCRIPTION
Hi,
In the current version of the module, the `rpfilter` parameter works as a no-op, no matter which value is provided since the feature is not specified. This commit fixes this issue.

Unfortunately, this is not the only issue with the parameter in question. The [xt_rpfilter](https://ipset.netfilter.org/iptables-extensions.man.html#lbBX) is one of the few extensions that perform meaningful work even when there are no extra parameters specified (in fact the default `strict` mode is invoked by just the `-m rpfilter` stanza), and currently, the Puppet module requires for the mode to be set to one of `loose`/`validmark`/`accept-local`/`invert`. In fact, all of these are optional flags and can be enabled simultaneously or not enabled at all. I'm not sure how to fix this and whether I should report this issue somewhere else. 

So while this PR addresses part of the problem with `rpfilter` parameter just doing nothing, it doesn't fix the main issue with `rpfilter` support. Currently, to use default `strict` matching one can work around the issue by using one of the flags that do not significantly affect the processing most of the time (such as setting `rpfilter => 'validmark'`), but this is only a hacky workaround, not a complete solution. Please advise on where should I report the issue so it could be fixed completely.