### PR TITLE
Add carp protocol to :proto property

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -554,7 +554,7 @@ Puppet::Type.newtype(:firewall) do
       The specific protocol to match for this rule.
     PUPPETCODE
 
-    newvalues(*[:ip, :tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :cbt, :sctp, :pim, :all].map { |proto|
+    newvalues(*[:ip, :tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :carp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :cbt, :sctp, :pim, :all].map { |proto|
       [proto, "! #{proto}".to_sym]
     }.flatten)
     defaultto 'tcp'

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -83,7 +83,7 @@ describe firewall do # rubocop:disable RSpec/MultipleDescribes
   end
 
   describe ':proto' do
-    [:ip, :tcp, :udp, :icmp, :esp, :ah, :vrrp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :pim, :all].each do |proto|
+    [:ip, :tcp, :udp, :icmp, :esp, :ah, :vrrp, :carp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :pim, :all].each do |proto|
       it "accepts proto value #{proto}" do
         resource[:proto] = proto
         expect(resource[:proto]).to eql proto


### PR DESCRIPTION
On Gentoo using 'vrrp' sets the proto to 112 but when puppet runs it interprets 112 as 'carp' which it then corrects to 'vrrp' which is still 112. So it redoes the rule every time puppet runs. Adding carp here allows carp to be set as a valid option which removes the loop.