### PR TITLE
pdksync - (IAC-1598) - Remove Support for Debian 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10",
         "11"


### PR DESCRIPTION
(IAC-1598) - Remove Support for Debian 8
pdk version: `2.1.1` 
