### PR TITLE
pdksync - (IAC-1751) - Add Support for Rocky 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -67,6 +67,12 @@
         "18.04",
         "20.04"
       ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
(IAC-1751) - Add Support for Rocky 8
pdk version: `2.1.1` 
