### PR TITLE
Fedora 34 and iptables-compat fix; properly utilising iptables param.

### DIFF
--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -45,6 +45,7 @@ class firewall::linux (
   }
 
   package { 'iptables':
+    name   => $package_name,
     ensure => $pkg_ensure,
   }
 

--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -31,6 +31,7 @@ class firewall::linux (
   $service_name_v6 = $firewall::params::service_name_v6,
   $package_name    = $firewall::params::package_name,
   $ebtables_manage = false,
+  $iptables_name   = $firewall::params::iptables_name,
 ) inherits ::firewall::params {
   $enable = $ensure ? {
     'running' => true,
@@ -45,7 +46,7 @@ class firewall::linux (
   }
 
   package { 'iptables':
-    name   => $package_name,
+    name   => $iptables_name,
     ensure => $pkg_ensure,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,16 +11,20 @@ class firewall::params {
           $service_name = 'iptables'
           $service_name_v6 = 'ip6tables'
           $package_name = undef
+          $iptables_name = 'iptables'
           $sysconfig_manage = true
         }
         'Fedora': {
           $service_name = 'iptables'
           $service_name_v6 = 'ip6tables'
           if versioncmp($::operatingsystemrelease, '34') >= 0 {
-            $package_name = 'iptables-compat'
+            $package_name = 'iptables-services'
+            $iptables_name = 'iptables-compat'
           } elsif versioncmp($::operatingsystemrelease, '15') >= 0 {
             $package_name = 'iptables-services'
+            $iptables_name = 'iptables'
           } else {
+            $iptables_name = 'iptables'
             $package_name = undef
           }
           $sysconfig_manage = true
@@ -30,16 +34,19 @@ class firewall::params {
             $service_name = ['iptables', 'nftables']
             $service_name_v6 = 'ip6tables'
             $package_name = ['iptables-services', 'nftables']
+            $iptables_name = 'iptables'
             $sysconfig_manage = false
           } elsif versioncmp($::operatingsystemrelease, '7.0') >= 0 {
             $service_name = 'iptables'
             $service_name_v6 = 'ip6tables'
             $package_name = 'iptables-services'
+            $iptables_name = 'iptables'
             $sysconfig_manage = true
           } else {
             $service_name = 'iptables'
             $service_name_v6 = 'ip6tables'
             $package_name = 'iptables-ipv6'
+            $iptables_name = 'iptables'
             $sysconfig_manage = true
           }
         }
@@ -47,6 +54,7 @@ class firewall::params {
     }
     'Debian': {
       $service_name_v6 = undef
+      $iptables_name = 'iptables'
       case $::operatingsystem {
         'Debian': {
           if versioncmp($::operatingsystemrelease, 'unstable') >= 0 {
@@ -81,6 +89,7 @@ class firewall::params {
       $package_name = 'net-firewall/iptables'
     }
     default: {
+      $iptables_name = 'iptables'
       $service_name_v6 = undef
       case $::operatingsystem {
         'Archlinux': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,9 @@ class firewall::params {
         'Fedora': {
           $service_name = 'iptables'
           $service_name_v6 = 'ip6tables'
-          if versioncmp($::operatingsystemrelease, '15') >= 0 {
+          if versioncmp($::operatingsystemrelease, '34') >= 0 {
+            $package_name = 'iptables-compat'
+          } elsif versioncmp($::operatingsystemrelease, '15') >= 0 {
             $package_name = 'iptables-services'
           } else {
             $package_name = undef


### PR DESCRIPTION
Improvement on PR - https://github.com/puppetlabs/puppetlabs-firewall/pull/1016 (https://github.com/puppetlabs/puppetlabs-firewall/pull/1016#discussion_r716869019)
See BUG - https://tickets.puppetlabs.com/browse/MODULES-11147

This minor change to the package to use the name field and param should also mean supporting other distros/package names be much easier, where as prior it was static.

Completely untested on Debian Distros; Tested on CentOS7, Fedora 33, Fedora 34. Can't forsee any issues.