### PR TITLE
fix service port number lookup to use protocol

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -382,6 +382,17 @@ Puppet::Type.newtype(:firewall) do
     end
   end
 
+  newproperty(:proto) do
+    desc <<-PUPPETCODE
+      The specific protocol to match for this rule.
+    PUPPETCODE
+
+    newvalues(*[:ip, :tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :carp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :cbt, :sctp, :pim, :all].map { |proto|
+      [proto, "! #{proto}".to_sym]
+    }.flatten)
+    defaultto 'tcp'
+  end
+
   newproperty(:sport, array_matching: :all) do
     desc <<-PUPPETCODE
       The source port to match for this filter (if the protocol supports
@@ -399,7 +410,7 @@ Puppet::Type.newtype(:firewall) do
     PUPPETCODE
 
     munge do |value|
-      @resource.string_to_port(value, :proto)
+      @resource.string_to_port(value, @resource[:proto])
     end
 
     def to_s?(value)
@@ -429,7 +440,7 @@ Puppet::Type.newtype(:firewall) do
     PUPPETCODE
 
     munge do |value|
-      @resource.string_to_port(value, :proto)
+      @resource.string_to_port(value, @resource[:proto])
     end
 
     def to_s?(value)
@@ -465,7 +476,7 @@ Puppet::Type.newtype(:firewall) do
     end
 
     munge do |value|
-      @resource.string_to_port(value, :proto)
+      @resource.string_to_port(value, @resource[:proto])
     end
 
     def to_s?(value)
@@ -566,17 +577,6 @@ Puppet::Type.newtype(:firewall) do
                   "! #{address_type} --limit-iface-out".to_sym,
                 ]
               }.flatten)
-  end
-
-  newproperty(:proto) do
-    desc <<-PUPPETCODE
-      The specific protocol to match for this rule.
-    PUPPETCODE
-
-    newvalues(*[:ip, :tcp, :udp, :icmp, :"ipv6-icmp", :esp, :ah, :vrrp, :carp, :igmp, :ipencap, :ipv4, :ipv6, :ospf, :gre, :cbt, :sctp, :pim, :all].map { |proto|
-      [proto, "! #{proto}".to_sym]
-    }.flatten)
-    defaultto 'tcp'
   end
 
   # tcp-specific

--- a/spec/unit/puppet/provider/iptables_spec.rb
+++ b/spec/unit/puppet/provider/iptables_spec.rb
@@ -331,14 +331,14 @@ describe 'iptables provider' do
                                        chain: 'nova-compute-FORWARD',
                                        source: '0.0.0.0/32',
                                        destination: '255.255.255.255/32',
-                                       sport: ['! 78', '79', 'http'],
+                                       sport: ['! 78', '79', 'talk'],
                                        dport: ['77', '! 76'],
                                        proto: 'udp')
     end
     let(:instance) { provider.new(resource) }
 
     it 'fails when not all array items are inverted' do
-      expect { instance.insert }.to raise_error RuntimeError, %r{but '79', '80' are not prefixed}
+      expect { instance.insert }.to raise_error RuntimeError, %r{but '79', '517' are not prefixed}
     end
   end
 


### PR DESCRIPTION
The existing code passes `:proto`, which `string_to_port` casts to a
string, gets "proto", compares that to the possibilities "udp" or "tcp",
and when neither, falls back to using "tcp".

This patch passes the actual proto value to the function, in case there is
a UDP specific service in your /etc/services (uncommon, but it happens).
It looks like Puppet will evaluate the properties in declared order,
so I had to move `newproperty(:proto)` up so `@resource[:proto]` was
available in the code for `sport`, `dport` and `port`.