### PR TITLE
CentOS Stream 9 Support (should include RHEL9 when that releases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## Uncommitted
+
+- Initial CentOS Stream 9/RHEL9 Support
+- Added a hook (not good enough yet) for deciding whether we try to remove
+  the firewalld package (we were removing it before, but it's necessary
+  on CS9/RHEL9 hosts)
+
 ## [v3.3.0](https://github.com/puppetlabs/puppetlabs-firewall/tree/v3.3.0) (2021-12-15)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-firewall/compare/v3.2.0...v3.3.0)

--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -41,6 +41,7 @@ class firewall::linux::redhat (
   $package_name     = $firewall::params::package_name,
   $package_ensure   = $firewall::params::package_ensure,
   $sysconfig_manage = $firewall::params::sysconfig_manage,
+  $firewalld_manage = true,
 ) inherits ::firewall::params {
   $_ensure_v6 = pick($ensure_v6, $ensure)
   $_enable_v6 = pick($enable_v6, $enable)
@@ -51,10 +52,12 @@ class firewall::linux::redhat (
   if ($::operatingsystem != 'Amazon')
   and (($::operatingsystem != 'Fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0)
   or  ($::operatingsystem == 'Fedora' and versioncmp($::operatingsystemrelease, '15') >= 0)) {
-    service { 'firewalld':
-      ensure => stopped,
-      enable => false,
-      before => [Package[$package_name], Service[$service_name]],
+    if $firewalld_manage {
+      service { 'firewalld':
+        ensure => stopped,
+        enable => false,
+        before => [Package[$package_name], Service[$service_name]],
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
-# @summary Provides defaults for the Apt module parameters.
-# 
+# @summary Provides defaults for the Apt module parameters
+#
 # @api private
 #
 class firewall::params {
@@ -30,7 +30,13 @@ class firewall::params {
           $sysconfig_manage = true
         }
         default: {
-          if versioncmp($::operatingsystemrelease, '8.0') >= 0 {
+          if versioncmp($::operatingsystemrelease, '9') >= 0 {
+            $service_name = 'nftables'
+            $service_name_v6 = undef
+            $package_name = ['iptables-services', 'nftables', 'iptables-nft-services']
+            $iptables_name = 'iptables'
+            $sysconfig_manage = false
+          } elsif versioncmp($::operatingsystemrelease, '8.0') >= 0 {
             $service_name = ['iptables', 'nftables']
             $service_name_v6 = 'ip6tables'
             $package_name = ['iptables-services', 'nftables']


### PR DESCRIPTION
CentOS Stream 9 and RHEL9 are firewalld based, so we need to add more hooks to at least not get in the way of firewalld.