### PR TITLE
(SEC-944) Handle duplicate system rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,15 +392,18 @@ firewall {'666 for NFLOG':
 
 ### Duplicate rule behaviour
 
-In certain situations it is possible for an unmanaged rule to exist on the target system that has the same comment as the rule specified in the manifest. This configuration is not supported by the firewall module.
+It is possible for an unmanaged rule to exist on the target system that has the same comment as the rule specified in the manifest. This configuration is not supported by the firewall module.
 
-In the event of a duplicate rule, the module will display a warning message notifying the user that it has found a duplicate but will continue to update the resource.
+In the event of a duplicate rule, the module will by default display a warning message notifying the user that it has found a duplicate but will continue to update the resource.
 
-This behaviour is configurable via the `onduplicaterulebehaviour` parameter. Users can choose from the following actions:
+This behaviour is configurable via the `onduplicaterulebehaviour` parameter. Users can choose from the following behaviours:
 
 * `ignore` - The duplicate rule is ignored and any updates to the resource will continue unaffected.
 * `warn` - The duplicate rule is logged as a warning and any updates to the resource will continue unaffected.
 * `error` - The duplicate rule is logged as an error and any updates to the resource will be skipped.
+
+With either the `ignore` or `warn` (default) behaviour, Puppet may create another duplicate rule.
+To prevent this behavior and report the resource as failing during the Puppet run, specify the `error` behaviour.
 
 ### Additional information
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@
 4. [Usage - Configuration and customization options](#usage)
     * [Default rules - Setting up general configurations for all firewalls](#default-rules)
     * [Application-specific rules - Options for configuring and managing firewalls across applications](#application-specific-rules)
-    * [Additional ses for the firewall module](#other-rules)
+    * [Rule inversion](#rule-inversion)
+    * [Additional uses for the firewall module](#additional-uses-for-the-firewal-module)
+    * [Duplicate rule behaviour](#duplicate-rule-behaviour)
+    * [Additional information](#additional-information)
 5. [Reference - An under-the-hood peek at what the module is doing](#reference)
 6. [Limitations - OS compatibility, etc.](#limitations)
 7. [Firewall_multi - Arrays for certain parameters](#firewall_multi)
@@ -386,6 +389,18 @@ firewall {'666 for NFLOG':
   nflog_threshold => 1,
 }
 ```
+
+### Duplicate rule behaviour
+
+In certain situations it is possible for an unmanaged rule to exist on the target system that has the same comment as the rule specified in the manifest. This configuration is not supported by the firewall module.
+
+In the event of a duplicate rule, the module will display a warning message notifying the user that it has found a duplicate but will continue to update the resource.
+
+This behaviour is configurable via the `onduplicaterulebehaviour` parameter. Users can choose from the following actions:
+
+* `ignore` - The duplicate rule is ignored and any updates to the resource will continue unaffected.
+* `warn` - The duplicate rule is logged as a warning and any updates to the resource will continue unaffected.
+* `error` - The duplicate rule is logged as an error and any updates to the resource will be skipped.
 
 ### Additional information
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -234,6 +234,24 @@ Puppet::Type.newtype(:firewall) do
     newvalues(%r{^\d+[[:graph:][:space:]]+$})
   end
 
+  newparam(:onduplicaterulebehaviour) do
+    desc <<-PUPPETCODE
+      In certain situations it is possible for an unmanaged rule to exist
+      on the target system that has the same comment as the rule
+      specified in the manifest.
+
+      This setting determines what happens when such a duplicate is found.
+
+      It offers three options:
+
+        * ignore - The duplicate rule is ignored and any updates to the resource will continue unaffected.
+        * warn - The duplicate rule is logged as a warning and any updates to the resource will continue unaffected.
+        * error - The duplicate rule is logged as an error and any updates to the resource will be skipped.
+    PUPPETCODE
+    newvalues(:ignore, :warn, :error)
+    defaultto :warn
+  end
+
   newproperty(:action) do
     desc <<-PUPPETCODE
       This is the action to perform on a match. Can be one of:

--- a/spec/acceptance/firewall_duplicate_comment_spec.rb
+++ b/spec/acceptance/firewall_duplicate_comment_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+def make_manifest(behaviour)
+  pp = <<-PUPPETCODE
+    class { 'firewall': }
+    resources { 'firewall':
+      purge => true,
+    }
+
+    firewall { '550 destination':
+      proto  => tcp,
+      dport   => '550',
+      action => accept,
+      destination => '192.168.2.0/24',
+      onduplicaterulebehaviour => #{behaviour}
+    }
+    PUPPETCODE
+
+  pp
+end
+
+describe 'firewall - duplicate comments' do
+  before(:all) do
+    if os[:family] == 'ubuntu' || os[:family] == 'debian'
+      update_profile_file
+    end
+  end
+
+  before(:each) do
+    run_shell('iptables -I INPUT -m state --state NEW -m tcp -p tcp --dport 551 -j ACCEPT -m comment --comment "550 destination"')
+  end
+
+  after(:each) do
+    iptables_flush_all_tables
+  end
+
+  context 'when onduplicateerrorhevent is set to error' do
+    it 'raises an error' do
+      run_shell('iptables -I INPUT -m state --state NEW -m tcp -p tcp --dport 551 -j ACCEPT -m comment --comment "550 destination"')
+      pp = make_manifest('error')
+
+      apply_manifest(pp) do |r|
+        expect(r.stderr).to include('Error: /Stage[main]/Main/Firewall[550 destination]: Could not evaluate: Duplicate rule found for 550 destination. Skipping update.')
+      end
+    end
+  end
+
+  context 'when onduplicateerrorhevent is set to warn' do
+    run_shell('iptables -I INPUT -m state --state NEW -m tcp -p tcp --dport 551 -j ACCEPT -m comment --comment "550 destination"')
+
+    it 'warns and continues' do
+      run_shell('iptables -I INPUT -m state --state NEW -m tcp -p tcp --dport 551 -j ACCEPT -m comment --comment "550 destination"')
+      pp = make_manifest('warn')
+
+      apply_manifest(pp) do |r|
+        expect(r.stderr).to include('Warning: Firewall[550 destination](provider=iptables): Duplicate rule found for 550 destination.. This may add an additional rule to the system.')
+      end
+    end
+  end
+
+  context 'when onduplicateerrorhevent is set to ignore' do
+    run_shell('iptables -I INPUT -m state --state NEW -m tcp -p tcp --dport 551 -j ACCEPT -m comment --comment "550 destination"')
+
+    it 'continues silently' do
+      run_shell('iptables -I INPUT -m state --state NEW -m tcp -p tcp --dport 551 -j ACCEPT -m comment --comment "550 destination"')
+      pp = make_manifest('ignore')
+
+      apply_manifest(pp) do |r|
+        expect(r.stderr).to be_empty
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -111,5 +111,12 @@ RSpec.configure do |c|
       }
     PUPPETCODE
     LitmusHelper.instance.apply_manifest(pp)
+
+    # Ensure that policycoreutils is present. In the future we could probably refactor
+    # this so that policycoreutils is installed on platform where the os.family fact
+    # is set to 'redhat'
+    if ['almalinux-8', 'rocky-8'].include?("#{fetch_os_name}-#{os[:release].to_i}")
+      LitmusHelper.instance.run_shell('yum install policycoreutils -y')
+    end
   end
 end


### PR DESCRIPTION
# Context

In certain situations it is possible for an unmanaged rule to exist on the target system that has the same comment as the rule specified in the manifest.

When this condition is true puppet will ignore the the unmanaged rule and continue to apply the rule in the manifest. This is because the firewall module uses the comment field in IPT as it's namevar and therefore expects it to be a unique identifier. In the case of IPT this is not true given that you can have multiple rules with the same comment.

# What has changed?

This commit adds a check that will identify system rules that have their comment field set to the same value as a rule in the manifest. If we enter a situation where any of the duplicate counts are greater than 1 then we will respond with a configurable action. The behaviour of this can be configured via the onduplicaterulebehaviour parameter.