### PR TITLE
fix "Skipping unparsable iptables rule" for rpfilter module

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -151,6 +151,10 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     rhitcount: '--hitcount',
     rname: '--name',
     rpfilter: '-m rpfilter',
+    loose: '--loose',
+    validmark: '--validmark',
+    accept_local: '--accept-local',
+    invert: '--invert',
     rseconds: '--seconds',
     rsource: '--rsource',
     rttl: '--rttl',
@@ -237,6 +241,10 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     :kernel_timezone,
     :queue_bypass,
     :notrack,
+    :loose,
+    :validmark,
+    :invert,
+    :accept_local,
   ]
 
   # Properties that use "-m <ipt module name>" (with the potential to have multiple
@@ -263,7 +271,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     geoip: [:src_cc, :dst_cc],
     hashlimit: [:hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst, :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask,
                 :hashlimit_htable_size, :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval],
-
+    rpfilter: [:loose, :validmark, :accept_local, :invert],
   }
 
   # Create property methods dynamically

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -141,6 +141,10 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     rhitcount: '--hitcount',
     rname: '--name',
     rpfilter: '-m rpfilter',
+    loose: '--loose',
+    validmark: '--validmark',
+    accept_local: '--accept-local',
+    invert: '--invert',
     rseconds: '--seconds',
     rsource: '--rsource',
     rttl: '--rttl',
@@ -237,6 +241,10 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :queue_bypass,
     :ipvs,
     :notrack,
+    :loose,
+    :validmark,
+    :invert,
+    :accept_local,
   ]
 
   # Properties that use "-m <ipt module name>" (with the potential to have multiple
@@ -263,6 +271,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     geoip: [:src_cc, :dst_cc],
     hashlimit: [:hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst, :hashlimit_mode, :hashlimit_srcmask, :hashlimit_dstmask,
                 :hashlimit_htable_size, :hashlimit_htable_max, :hashlimit_htable_expire, :hashlimit_htable_gcinterval],
+    rpfilter: [:loose, :validmark, :accept_local, :invert],
   }
 
   def self.munge_resource_map_from_existing_values(resource_map_original, compare)


### PR DESCRIPTION
Currently, the iptables module rpfilter is not parsed correctly. This leads to it throwing a warning during a puppet run. 

Example of such a warning:
`Warning: Puppet::Type::Firewall::ProviderIptables: Skipping unparsable iptables rule: keys (5) and values (6) count mismatch on line: -A cali-PREROUTING -m comment --comment "cali:mPIOOWmbH3iO0R90" -m mark --mark 0x40000/0x40000 -m rpfilter --validmark --invert -j DROP`

I've fixed the parsing of rpfilter and it's boolean arguments (--loose, --validmark, --accept-local, --invert) according to https://ipset.netfilter.org/iptables-extensions.man.html#lbBX

The change was able to fix the issue in our test environment and the parsing was correct.

For testing I would need some support as I am not quite sure where and how to implement them. 