### PR TITLE
Fix bug with ip6tables version parsing during initialization

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
 
   def initialize(*args)
     ip6tables_version = Facter.value('ip6tables_version')
-    raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if ip6tables_version&.match(%r{1\.3\.\d})
+    raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if ip6tables_version && ip6tables_version.match(%r{1\.3\.\d})
     super
   end
 


### PR DESCRIPTION
Fixes regression introduced by this PR:
https://github.com/puppetlabs/puppetlabs-firewall/pull/964