### PR TITLE
(GH-1055) Fix for `--random-fully`

### DIFF
--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -551,7 +551,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
                  values.sub(%r{'#{resource_map[bool]} "! "'}, "#{resource_map[bool]} true")
                else
                  # append `true` to booleans that are not already negated (followed by "!")
-                 values.sub(%r{#{resource_map[bool]}(?=\s|$)(?!"!")}, "#{resource_map[bool]} true")
+                 values.sub(%r{#{resource_map[bool]}(?=\s|$)(?!\s?"!")}, "#{resource_map[bool]} true")
                end
     end
 

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -549,11 +549,9 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
                  values.sub(%r{\s-f(?!l)(?=.*--comment)}, ' -f true')
                elsif resource_map[bool].eql?(%r{'--physdev-is-\S+'})
                  values.sub(%r{'#{resource_map[bool]} "! "'}, "#{resource_map[bool]} true")
-               elsif bool == :random
-                 values.sub(%r{#{resource_map[bool]}(\s|$)(?!"!")}, "#{resource_map[bool]} true")
                else
                  # append `true` to booleans that are not already negated (followed by "!")
-                 values.sub(%r{#{resource_map[bool]}(?! "!")}, "#{resource_map[bool]} true")
+                 values.sub(%r{#{resource_map[bool]}(?=\s|$)(?!"!")}, "#{resource_map[bool]} true")
                end
     end
 


### PR DESCRIPTION
Issues have arisen with the --random-fully value on certain RedHat versions.
It seem's as if the logic put in around `--random` and `--random-fully` are no longer working.
This change should resolve the issue and tighten the logic around the `known_boolean` values.