### PR TITLE
add support for using rpfilter in rules

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1705,7 +1705,7 @@ Puppet::Type.newtype(:firewall) do
     newvalues(:true, :false)
   end
 
-  newproperty(:rpfilter, required_features: :rpfilter) do
+  newproperty(:rpfilter, required_features: :rpfilter, array_matching: :all) do
     desc <<-PUPPETCODE
       Enable the rpfilter module.
     PUPPETCODE
@@ -1713,6 +1713,10 @@ Puppet::Type.newtype(:firewall) do
     newvalues(:loose, :validmark, :'accept-local', :invert)
     munge do |value|
       _value = '--' + value
+    end
+
+    def insync?(is)
+      is.to_set == should.to_set
     end
   end
 

--- a/spec/acceptance/firewall_attributes_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_happy_path_spec.rb
@@ -334,6 +334,12 @@ describe 'firewall attribute testing, happy path' do
             table    => 'raw',
             chain    => 'PREROUTING',
             action   => 'accept',
+            rpfilter => [ 'invert', 'validmark', 'loose', 'accept-local' ],
+          }
+          firewall { '901 - set rpfilter':
+            table    => 'raw',
+            chain    => 'PREROUTING',
+            action   => 'accept',
             rpfilter => 'invert',
           }
           firewall { '1000 - set_dscp':
@@ -420,6 +426,12 @@ describe 'firewall attribute testing, happy path' do
     end
     it 'toports is set' do
       expect(result.stdout).to match(%r{-A PREROUTING -p icmp -m comment --comment "574 - toports" -j REDIRECT --to-ports 2222})
+    end
+    it 'rpfilter is set' do
+      expect(result.stdout).to match(%r{-A PREROUTING -p tcp -m rpfilter --loose --validmark --accept-local --invert -m comment --comment "900 - set rpfilter" -j ACCEPT})
+    end
+    it 'single rpfilter is set' do
+      expect(result.stdout).to match(%r{-A PREROUTING -p tcp -m rpfilter --invert -m comment --comment "901 - set rpfilter" -j ACCEPT})
     end
     it 'limit is set' do
       expect(result.stdout).to match(%r{-A INPUT -p tcp -m multiport --dports 572 -m limit --limit 500\/sec -m comment --comment "572 - limit" -j ACCEPT})


### PR DESCRIPTION
When rules with rpfilter are used, then there are warnings like these in the output:

`Warning: Puppet::Type::Firewall::ProviderIptables: Skipping unparsable iptables rule: keys (5) and values (6) count mismatch on line: -A cali-PREROUTING -m comment --comment "cali:mPIOOWmbH3iO0R90" -m mark --mark 0x40000/0x40000 -m rpfilter --validmark --invert -j DROP`