### PR TITLE
allow persistence of firewall rules for Suse

### DIFF
--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -241,6 +241,12 @@ module Puppet::Util::Firewall
               ['/bin/sh', '-c', '/usr/sbin/ip6tables-save > /etc/iptables/ip6tables.rules']
             end
           end
+          when :Suse
+            case proto.to_sym
+            when :IPv4
+              ['/bin/sh', '-c', '/usr/sbin/iptables-save > /etc/sysconfig/iptables']
+            end
+          end
 
     # Catch unsupported OSs from the case statement above.
     if cmd.nil?

--- a/lib/puppet/util/firewall.rb
+++ b/lib/puppet/util/firewall.rb
@@ -240,7 +240,6 @@ module Puppet::Util::Firewall
             when :IPv6
               ['/bin/sh', '-c', '/usr/sbin/ip6tables-save > /etc/iptables/ip6tables.rules']
             end
-          end
           when :Suse
             case proto.to_sym
             when :IPv4


### PR DESCRIPTION
allow persistence of firewall rules for Suse by using `iptables-save`.