### PR TITLE
pdksync - (GH-cat-11) Certify Support for Ubuntu 22.04

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1874,8 +1874,8 @@ Puppet::Type.newtype(:firewall) do
     PUPPETCODE
     newvalues(%r{^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$}i)
     facter_os_name = Facter.value(:os)['name'].downcase
-    facter_os_release = Facter.value(:os)['release']['major'].to_i
-    if ['debian-11', 'sles-15'].include?("#{facter_os_name}-#{facter_os_release}")
+    facter_os_release = Facter.value(:os)['release']['major']
+    if ['ubuntu-22.04', 'debian-11', 'sles-15'].include?("#{facter_os_name}-#{facter_os_release}")
       munge do |value|
         _value = value.downcase
       end

--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
(GH-cat-11) Certify Support for Ubuntu 22.04
pdk version: `2.4.0` 
