### PR TITLE
(MAINT) Refactoring OSs based on puppet agent docs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,8 +26,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this instance, CentOS 8 has been removed from the supported OSs in metadata.json.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html