### PR TITLE
pdksync - (CONT-189) Remove support for RedHat6 / OracleLinux6 / Scientific6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8",
         "9"

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
CONT-189/remove_os_support
pdk version: `2.5.0` 
