### PR TITLE
(CONT-173) - Updating deprecated facter instances

### DIFF
--- a/lib/facter/ip6tables_version.rb
+++ b/lib/facter/ip6tables_version.rb
@@ -3,7 +3,7 @@
 Facter.add(:ip6tables_version) do
   confine kernel: :Linux
   setcode do
-    version = Facter::Util::Resolution.exec('ip6tables --version')
+    version = Facter::Core::Execution.execute('ip6tables --version')
     if version
       version.match(%r{\d+\.\d+\.\d+}).to_s
     else

--- a/lib/facter/iptables_persistent_version.rb
+++ b/lib/facter/iptables_persistent_version.rb
@@ -14,7 +14,7 @@ Facter.add(:iptables_persistent_version) do
           else
             "dpkg-query -Wf '${Version}' iptables-persistent 2>/dev/null"
           end
-    version = Facter::Util::Resolution.exec(cmd)
+    version = Facter::Core::Execution.execute(cmd)
 
     if version.nil? || !version.match(%r{\d+\.\d+})
       nil

--- a/lib/facter/iptables_version.rb
+++ b/lib/facter/iptables_version.rb
@@ -3,7 +3,7 @@
 Facter.add(:iptables_version) do
   confine kernel: :Linux
   setcode do
-    version = Facter::Util::Resolution.exec('iptables --version')
+    version = Facter::Core::Execution.execute('iptables --version')
     if version
       version.match(%r{\d+\.\d+\.\d+}).to_s
     else

--- a/spec/unit/facter/iptables_persistent_version_spec.rb
+++ b/spec/unit/facter/iptables_persistent_version_spec.rb
@@ -17,8 +17,8 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
         before(:each) do
           allow(Facter.fact(:operatingsystem)).to receive(:value).and_return(os)
           allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return(os_release)
-          allow(Facter::Util::Resolution).to receive(:exec).with(dpkg_cmd)
-                                                           .and_return(ver)
+          allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+                                                             .and_return(ver)
         end
         it { expect(Facter.fact(:iptables_persistent_version).value).to eql ver }
       end
@@ -28,8 +28,8 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Ubuntu')
         allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return('20.04')
-        allow(Facter::Util::Resolution).to receive(:exec).with(dpkg_cmd)
-                                                         .and_return(nil)
+        allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+                                                           .and_return(nil)
       end
       it { expect(Facter.fact(:iptables_persistent_version).value).to be_nil }
     end
@@ -62,8 +62,8 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
         before(:each) do
           allow(Facter.fact(:operatingsystem)).to receive(:value).and_return(os)
           allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return(os_release)
-          allow(Facter::Util::Resolution).to receive(:exec).with(dpkg_cmd)
-                                                           .and_return(ver)
+          allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+                                                             .and_return(ver)
         end
         it { expect(Facter.fact(:iptables_persistent_version).value).to eql ver }
       end
@@ -74,8 +74,8 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Ubuntu')
         allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return(os_release)
-        allow(Facter::Util::Resolution).to receive(:exec).with(dpkg_cmd)
-                                                         .and_return(nil)
+        allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+                                                           .and_return(nil)
       end
       it { expect(Facter.fact(:iptables_persistent_version).value).to be_nil }
     end

--- a/spec/unit/facter/iptables_spec.rb
+++ b/spec/unit/facter/iptables_spec.rb
@@ -11,15 +11,15 @@ describe 'Facter::Util::Fact' do
 
   describe 'iptables_version' do
     it {
-      allow(Facter::Util::Resolution).to receive(:exec).with('iptables --version')
-                                                       .and_return('iptables v1.4.7')
+      allow(Facter::Core::Execution).to receive(:execute).with('iptables --version')
+                                                         .and_return('iptables v1.4.7')
       expect(Facter.fact(:iptables_version).value).to eql '1.4.7'
     }
   end
 
   describe 'ip6tables_version' do
     before(:each) do
-      allow(Facter::Util::Resolution).to receive(:exec)
+      allow(Facter::Core::Execution).to receive(:execute)
         .with('ip6tables --version').and_return('ip6tables v1.4.7')
     end
     it { expect(Facter.fact(:ip6tables_version).value).to eql '1.4.7' }


### PR DESCRIPTION
Prior to this PR, this module contained instances of Facter::Util::Resolution.exec and Facter::Util::Resolution.which, which are deprecated. This PR aims to replace these exec helpers with their supported Facter::Core::Execution counterparts.

This PR:

- Replaced all Facter::Util::Resolution instances with corresponding Facter::Core::Execution exec helpers