### PR TITLE
Revert "Add negate to match_mark"

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1481,33 +1481,28 @@ Puppet::Type.newtype(:firewall) do
     desc <<-PUPPETCODE
       Match the Netfilter mark value associated with the packet.  Accepts either of:
       mark/mask or mark.  These will be converted to hex if they are not already.
-
-      match_mark => '0x02'
-
-      You can also negate a value by putting ! in front. For example:
-
-      match_mark => '! 0x02'
     PUPPETCODE
     munge do |value|
-      mark_regex = %r{\A(!\s)?((?:0x)?[0-9A-F]+)(/)?((?:0x)?[0-9A-F]+)?\z}i
+      mark_regex = %r{\A((?:0x)?[0-9A-F]+)(/)?((?:0x)?[0-9A-F]+)?\z}i
       match = value.to_s.match(mark_regex)
       if match.nil?
         raise ArgumentError, 'Match MARK value must be integer or hex between 0 and 0xffffffff'
       end
-      mark = @resource.to_hex32(match[2])
+      mark = @resource.to_hex32(match[1])
 
       # Values that can't be converted to hex.
       # Or contain a trailing slash with no mask.
-      if mark.nil? || (mark && match[3] && match[4].nil?)
+      if mark.nil? || (mark && match[2] && match[3].nil?)
         raise ArgumentError, 'Match MARK value must be integer or hex between 0 and 0xffffffff'
       end
 
       # There should not be a mask on match_mark
-      unless match[4].nil?
+      unless match[3].nil?
         raise ArgumentError, 'iptables does not support masks on MARK match rules'
       end
+      value = mark
 
-      match[1] ? "! #{mark}" : mark
+      value
     end
   end
 

--- a/manifests/linux/debian.pp
+++ b/manifests/linux/debian.pp
@@ -34,7 +34,7 @@ class firewall::linux::debian (
 
       refreshonly => true,
     }
-    ensure_packages([$package_name],{
+    ensure_packages([$package_name], {
         ensure  => $package_ensure,
         require => Exec['iptables-persistent-debconf']
     })

--- a/spec/acceptance/firewall_attributes_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_exceptions_spec.rb
@@ -1251,25 +1251,6 @@ describe 'firewall basics', docker: true do
             expect(r.stdout).to match(%r{-A INPUT -m mark --mark 0x1 -m comment --comment "503 match_mark - test" -j REJECT --reject-with icmp-port-unreachable})
           end
         end
-
-        context 'when ! 0x1' do
-          pp1 = <<-PUPPETCODE
-              class { '::firewall': }
-              firewall { '504 match_mark - negate test':
-                proto      => 'all',
-                match_mark => '! 0x1',
-                action     => reject,
-              }
-          PUPPETCODE
-          it 'applies' do
-            apply_manifest(pp1, catch_failures: true)
-          end
-
-          it 'contains the rule' do
-            run_shell('iptables-save') do |r|
-              expect(r.stdout).to match(%r{-A INPUT -m mark --mark ! 0x1 -m comment --comment "504 match_mark - negate test" -j REJECT --reject-with icmp-port-unreachable})
-            end
-          end
       end
     end
 


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-firewall#1066

Prior to this commit nightlies and all tests on main are failing. 

This commit reverts a PR that was merged as it looked sensible and and suggested all tests passed. However as an oversight only the CLA check ran therefore the test results presented were misleading. Initially I tried to resolve with adding the missing `end` however the failures run deeper than this therefore the best decision would be to revert this PR. 