### PR TITLE
package "iptables" has been replaced by "iptables-nft" on EL9

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class firewall::params {
             $service_name = 'nftables'
             $service_name_v6 = 'ip6tables'
             $package_name = ['iptables-services', 'nftables', 'iptables-nft-services']
-            $iptables_name = 'iptables'
+            $iptables_name = 'iptables-nft'
             $sysconfig_manage = false
             $firewalld_manage = false
           } elsif versioncmp($::operatingsystemrelease, '8.0') >= 0 {


### PR DESCRIPTION
There are some pointers given by dnf about "iptables", but these confuse Puppet into aborting with the error message:

```console
Error: /Stage[main]/Firewall::Linux/Package[iptables]: Could not evaluate: no implicit conversion of Array into Hash
```

Fedora had a similar patch in commit 486e4b5779f5069e which I think fixed the bug https://tickets.puppetlabs.com/browse/MODULES-11147 but the same issue rared its head here on AlmaLinux 9.0.

The RPM for iptables-legacy states:

> This package contains the legacy tools which are obsoleted by
> nft-variants in iptables-nft package for backwards compatibility reasons.
> If you need to set up firewalls and/or IP masquerading, you should not install
> this package but either nftables or iptables-nft instead.