### PR TITLE
(CONT-5) Codebase hardening

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -74,7 +74,10 @@ class firewall::linux::redhat (
 
   if ($::operatingsystem != 'Amazon') {
     if $ensure == 'running' {
+      $running_command = ['/usr/bin/systemctl', 'daemon-reload']
+
       exec { '/usr/bin/systemctl daemon-reload':
+        command     => $running_command,
         require     => Package[$package_name],
         before      => Service[$service_name, $service_name_v6],
         subscribe   => Package[$package_name],


### PR DESCRIPTION
Prior to this commit, and after the work perform in CONT-256, there were a few commands in the module that were not properly sanitised according to our current standards.

This PR aims to implement some changes that ensure no malformed commands are passed through to the system. Primarily, the commands targeted were the ones related to Open3 and exec.