### PR TITLE
(CONT-5) Raising minimum required puppet version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
Prior to this commit, and as part of the codebase hardening project, we sanitised some commands in the module. However, this sanitisation method requires that users have at least puppet version 6.24.0 and onwards to be effective.

This commit aims to resolve that requirement by raising the required puppet version in the metadata.json file.