### PR TITLE
Revert "(CONT-5) Raising minimum required puppet version"

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.24.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-firewall#1088

Firewall codebase hardening does not include any 'unless' nor 'onlyif' updates. Therefore, raising the minimum puppet required version may not be necessary.