### PR TITLE
(1093) - Fix unresolved fact error

### DIFF
--- a/lib/facter/ip6tables_version.rb
+++ b/lib/facter/ip6tables_version.rb
@@ -2,12 +2,9 @@
 
 Facter.add(:ip6tables_version) do
   confine kernel: :Linux
+  confine { Facter::Core::Execution.which('ip6tables') }
   setcode do
-    version = Facter::Core::Execution.execute('ip6tables --version')
-    if version
-      version.match(%r{\d+\.\d+\.\d+}).to_s
-    else
-      nil
-    end
+    version = Facter::Core::Execution.execute('ip6tables --version', { on_fail: nil })
+    version.match(%r{\d+\.\d+\.\d+}).to_s if version
   end
 end

--- a/lib/facter/iptables_persistent_version.rb
+++ b/lib/facter/iptables_persistent_version.rb
@@ -6,7 +6,7 @@ Facter.add(:iptables_persistent_version) do
     # Throw away STDERR because dpkg >= 1.16.7 will make some noise if the
     # package isn't currently installed.
     cmd = "dpkg-query -Wf '${Version}' netfilter-persistent 2>/dev/null"
-    version = Facter::Core::Execution.execute(cmd)
+    version = Facter::Core::Execution.execute(cmd, { on_fail: nil })
 
     if version.nil? || !version.match(%r{\d+\.\d+})
       nil

--- a/lib/facter/iptables_version.rb
+++ b/lib/facter/iptables_version.rb
@@ -2,12 +2,9 @@
 
 Facter.add(:iptables_version) do
   confine kernel: :Linux
+  confine { Facter::Core::Execution.which('iptables') }
   setcode do
-    version = Facter::Core::Execution.execute('iptables --version')
-    if version
-      version.match(%r{\d+\.\d+\.\d+}).to_s
-    else
-      nil
-    end
+    version = Facter::Core::Execution.execute('iptables --version', { on_fail: nil })
+    version.match(%r{\d+\.\d+\.\d+}).to_s if version
   end
 end

--- a/spec/unit/facter/iptables_persistent_version_spec.rb
+++ b/spec/unit/facter/iptables_persistent_version_spec.rb
@@ -17,7 +17,7 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
         before(:each) do
           allow(Facter.fact(:operatingsystem)).to receive(:value).and_return(os)
           allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return(os_release)
-          allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+          allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd, { on_fail: nil })
                                                              .and_return(ver)
         end
         it { expect(Facter.fact(:iptables_persistent_version).value).to eql ver }
@@ -28,7 +28,7 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Ubuntu')
         allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return('20.04')
-        allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+        allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd, { on_fail: nil })
                                                            .and_return(nil)
       end
       it { expect(Facter.fact(:iptables_persistent_version).value).to be_nil }
@@ -62,7 +62,7 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
         before(:each) do
           allow(Facter.fact(:operatingsystem)).to receive(:value).and_return(os)
           allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return(os_release)
-          allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+          allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd, { on_fail: nil })
                                                              .and_return(ver)
         end
         it { expect(Facter.fact(:iptables_persistent_version).value).to eql ver }
@@ -74,7 +74,7 @@ describe 'Facter::Util::Fact iptables_persistent_version' do
       before(:each) do
         allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Ubuntu')
         allow(Facter.fact(:operatingsystemrelease)).to receive(:value).and_return(os_release)
-        allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd)
+        allow(Facter::Core::Execution).to receive(:execute).with(dpkg_cmd, { on_fail: nil })
                                                            .and_return(nil)
       end
       it { expect(Facter.fact(:iptables_persistent_version).value).to be_nil }

--- a/spec/unit/facter/iptables_spec.rb
+++ b/spec/unit/facter/iptables_spec.rb
@@ -11,16 +11,20 @@ describe 'Facter::Util::Fact' do
 
   describe 'iptables_version' do
     it {
-      allow(Facter::Core::Execution).to receive(:execute).with('iptables --version')
-                                                         .and_return('iptables v1.4.7')
+      allow(Facter::Core::Execution).to receive(:which)
+        .with('iptables').and_return('/usr/sbin/iptables')
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('iptables --version', { on_fail: nil }).and_return('iptables v1.4.7')
       expect(Facter.fact(:iptables_version).value).to eql '1.4.7'
     }
   end
 
   describe 'ip6tables_version' do
     before(:each) do
+      allow(Facter::Core::Execution).to receive(:which)
+        .with('ip6tables').and_return('/usr/sbin/ip6tables')
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('ip6tables --version').and_return('ip6tables v1.4.7')
+        .with('ip6tables --version', { on_fail: nil }).and_return('ip6tables v1.4.7')
     end
     it { expect(Facter.fact(:ip6tables_version).value).to eql '1.4.7' }
   end


### PR DESCRIPTION
Fix for https://github.com/puppetlabs/puppetlabs-firewall/issues/1093

Prior to this PR, work was carried out on this module to update all instances of the now deprecated Facter::Util::Resolution, and replace all with its newer and supported counterpart Facter::Core::Execution. 
However, these do not behave exactly the same. 

Facter::Util::Resolution initially ran a which to locate the binary before executing, preventing any errors from occuring. The newer Facter::Core::Execution method did not do this, instead it attempted to execute.

This commit aims to introduce an "on_fail:false" flag to each execute statement, so that a failed execute will return false (boolean) and not generate an error.