### PR TITLE
support --nflog-size as replacement for --nflog-range

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ firewall {'666 for NFLOG':
   jump            => 'NFLOG',
   nflog_group     => 3,
   nflog_prefix    => 'nflog-test',
-  nflog_range     => 256,
+  nflog_size      => 256,
   nflog_threshold => 1,
 }
 ```

--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -70,6 +70,10 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     has_feature :rpfilter
   end
 
+  if ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.6.1') >= 0
+    has_feature :nflog_size
+  end
+
   def initialize(*args)
     ip6tables_version = Facter.value('ip6tables_version')
     raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if ip6tables_version&.match(%r{1\.3\.\d})
@@ -140,6 +144,7 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
     nflog_group: '--nflog-group',
     nflog_prefix: '--nflog-prefix',
     nflog_range: '--nflog-range',
+    nflog_size: '--nflog-size',
     nflog_threshold: '--nflog-threshold',
     outiface: '-o',
     pkttype: '-m pkttype --pkt-type',
@@ -313,7 +318,9 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
                     :ctorigsrcport, :ctorigdstport, :ctreplsrcport, :ctrepldstport, :ctstatus, :ctexpire, :ctdir,
                     :icmp, :hop_limit, :limit, :burst, :length, :recent, :rseconds, :reap,
                     :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :string, :string_hex, :string_algo,
-                    :string_from, :string_to, :jump, :nflog_group, :nflog_prefix, :nflog_range, :nflog_threshold, :clamp_mss_to_pmtu, :gateway, :todest,
+                    :string_from, :string_to, :jump,
+                    :nflog_group, :nflog_prefix, :nflog_range, :nflog_size, :nflog_threshold,
+                    :clamp_mss_to_pmtu, :gateway, :todest,
                     :tosource, :toports, :checksum_fill, :log_level, :log_prefix, :log_uid, :log_tcp_sequence, :log_tcp_options, :log_ip_options, :random_fully,
                     :reject, :set_mss, :set_dscp, :set_dscp_class, :mss, :queue_num, :queue_bypass,
                     :set_mark, :match_mark, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -76,6 +76,10 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     has_feature :rpfilter
   end
 
+  if iptables_version && Puppet::Util::Package.versioncmp(iptables_version, '1.6.1') >= 0
+    has_feature :nflog_size
+  end
+
   @protocol = 'IPv4'
 
   @resource_map = {
@@ -129,6 +133,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     nflog_group: '--nflog-group',
     nflog_prefix: '--nflog-prefix',
     nflog_range: '--nflog-range',
+    nflog_size: '--nflog-size',
     nflog_threshold: '--nflog-threshold',
     outiface: '-o',
     pkttype: '-m pkttype --pkt-type',
@@ -351,7 +356,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     :rhitcount, :rttl, :rname, :mask, :rsource, :rdest, :ipset, :string, :string_hex, :string_algo,
     :string_from, :string_to, :jump, :goto, :clusterip_new, :clusterip_hashmode,
     :clusterip_clustermac, :clusterip_total_nodes, :clusterip_local_node, :clusterip_hash_init, :queue_num, :queue_bypass,
-    :nflog_group, :nflog_prefix, :nflog_range, :nflog_threshold, :clamp_mss_to_pmtu, :gateway,
+    :nflog_group, :nflog_prefix, :nflog_range, :nflog_size, :nflog_threshold, :clamp_mss_to_pmtu, :gateway,
     :set_mss, :set_dscp, :set_dscp_class, :todest, :tosource, :toports, :to, :checksum_fill, :random_fully, :random, :log_prefix,
     :log_level, :log_uid, :log_tcp_sequence, :log_tcp_options, :log_ip_options, :reject, :set_mark, :match_mark, :mss, :connlimit_above, :connlimit_mask, :connmark, :time_start, :time_stop,
     :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -110,7 +110,7 @@ Puppet::Type.newtype(:firewall) do
 
       * nflog_prefix: The ability to set a prefix for nflog messages.
 
-      * nflog_range: The ability to set nflog_range.
+      * nflog_size: Set the max size of a message to send to nflog.
 
       * nflog_threshold: The ability to set nflog_threshold.
 
@@ -187,6 +187,7 @@ Puppet::Type.newtype(:firewall) do
   feature :nflog_group, 'netlink group to subscribe to for logging'
   feature :nflog_prefix, ''
   feature :nflog_range, ''
+  feature :nflog_size, ''
   feature :nflog_threshold, ''
   feature :ipset, 'Match against specified ipset list'
   feature :clusterip, 'Configure a simple cluster of nodes that share a certain IP and MAC address without an explicit load balancer in front of them.'
@@ -897,8 +898,15 @@ Puppet::Type.newtype(:firewall) do
   newproperty(:nflog_range, required_features: :nflog_range) do
     desc <<-PUPPETCODE
       Used with the jump target NFLOG.
+      This has never worked, use nflog_size instead.
+    PUPPETCODE
+  end
+
+  newproperty(:nflog_size, required_features: :nflog_size) do
+    desc <<-PUPPETCODE
+      Used with the jump target NFLOG.
       The number of bytes to be copied to userspace (only applicable for nfnetlink_log).
-      nfnetlink_log instances may specify their own range, this option overrides it.
+      nfnetlink_log instances may specify their own size, this option overrides it.
     PUPPETCODE
   end
 

--- a/spec/acceptance/firewall_attributes_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_exceptions_spec.rb
@@ -406,7 +406,8 @@ describe 'firewall basics', docker: true do
       end
     end
 
-    describe 'nflog_range' do
+    # --nflog-range was deprecated and replaced by --nflog-size in iptables 1.6.1
+    describe 'nflog_range', unless: iptables_version > '1.6.0' do
       it 'applies' do
         pp4 = <<-PUPPETCODE
           class {'::firewall': }
@@ -418,6 +419,22 @@ describe 'firewall basics', docker: true do
       it 'contains the rule' do
         run_shell('iptables-save') do |r|
           expect(r.stdout).to match(%r{NFLOG --nflog-range 16})
+        end
+      end
+    end
+
+    describe 'nflog_size', unless: iptables_version < '1.6.1' do
+      it 'applies' do
+        pp4 = <<-PUPPETCODE
+          class {'::firewall': }
+          firewall { '503 - test': jump  => 'NFLOG', proto => 'all', nflog_size => 16}
+        PUPPETCODE
+        apply_manifest(pp4, catch_failures: true)
+      end
+
+      it 'contains the rule' do
+        run_shell('iptables-save') do |r|
+          expect(r.stdout).to match(%r{NFLOG --nflog-size 16})
         end
       end
     end


### PR DESCRIPTION
--nflog-range was deprecated way back in 2016.

https://git.netfilter.org/iptables/commit/?h=v1.6.1&id=7070b1f3c88a0c3d4e315c00cca61f05b0fbc882