### PR TITLE
(GH-1097) Bumping back required puppet version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
Prior to this commit, due to a mistake, there was a reversion to the previously implemented bump to minimum required puppet version, which was part of the CVE update.

This commit aims to address issue 1097 in Github which brings to light the need for this puppet bump to be restored to 6.24