### PR TITLE
enable correct service for EL9 using legacy IPv4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,14 +30,14 @@ class firewall::params {
         }
         default: {
           if versioncmp($facts['os']['release']['full'], '9') >= 0 {
-            $service_name = ['nftables','iptables']
+            $service_name = 'iptables'
             $service_name_v6 = 'ip6tables'
             $package_name = ['iptables-services', 'nftables', 'iptables-nft-services']
             $iptables_name = 'iptables-nft'
             $sysconfig_manage = false
             $firewalld_manage = true
           } elsif versioncmp($facts['os']['release']['full'], '8.0') >= 0 {
-            $service_name = ['iptables', 'nftables']
+            $service_name = ['iptables']
             $service_name_v6 = 'ip6tables'
             $package_name = ['iptables-services', 'nftables']
             $iptables_name = 'iptables'

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -147,10 +147,6 @@ describe 'firewall::linux::redhat', type: :class do
         end
 
         it {
-          expect(subject).to contain_service('nftables').with(
-            ensure: 'running',
-            enable: 'true',
-          )
           expect(subject).to contain_service('iptables').with(
             ensure: 'running',
             enable: 'true',
@@ -161,9 +157,6 @@ describe 'firewall::linux::redhat', type: :class do
           let(:params) { { ensure: 'stopped' } }
 
           it {
-            expect(subject).to contain_service('nftables').with(
-              ensure: 'stopped',
-            )
             expect(subject).to contain_service('iptables').with(
               ensure: 'stopped',
             )
@@ -174,9 +167,6 @@ describe 'firewall::linux::redhat', type: :class do
           let(:params) { { enable: 'false' } }
 
           it {
-            expect(subject).to contain_service('nftables').with(
-              enable: 'false',
-            )
             expect(subject).to contain_service('iptables').with(
               enable: 'false',
             )
@@ -187,21 +177,21 @@ describe 'firewall::linux::redhat', type: :class do
           expect(subject).to contain_service('firewalld').with(
             ensure: 'stopped',
             enable: false,
-            before: ['Package[iptables-services]', 'Package[nftables]', 'Service[iptables]', 'Service[nftables]'],
+            before: ['Package[iptables-services]', 'Package[nftables]', 'Service[iptables]'],
           )
         }
 
         it {
           expect(subject).to contain_package('iptables-services').with(
             ensure: 'installed',
-            before: ['Service[iptables]', 'Service[nftables]'],
+            before: ['Service[iptables]'],
           )
         }
 
         it {
           expect(subject).to contain_package('nftables').with(
             ensure: 'installed',
-            before: ['Service[iptables]', 'Service[nftables]'],
+            before: ['Service[iptables]'],
           )
         }
 


### PR DESCRIPTION
probably not many people still using IPv4 in their systems, after all IPv6 is soon 25 years old, but... we still want to support it.

nftables.service loads nft rules from /etc/sysconfig/nftables.conf, but this module generates classic iptables rules.  The service to load these on boot is simply "iptables.service".

IPv6 rules are loaded correctly by ip6tables.service.