### PR TITLE
Force firewall chain delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ resources { 'firewallchain':
 }
 ```
 
-> **Note:** If there are unmanaged rules in unmanaged chains, it will take a second Puppet run for the firewall chain to be purged.
-
 > **Note:** If you need more fine-grained control about which unmananged rules get removed, investigate the `purge` and `ignore_foreign` parameters available in `firewallchain`.
+
+> **Note:** `ignore_foreign` of `firewallchain` does not work as expected with a resources purge of `firewall`.
 
 ### Upgrading
 

--- a/lib/puppet/provider/firewallchain/iptables_chain.rb
+++ b/lib/puppet/provider/firewallchain/iptables_chain.rb
@@ -60,12 +60,14 @@ Puppet::Type.type(:firewallchain).provide :iptables_chain do
   end
 
   def destroy
-    allvalidchains do |t, chain, table|
+    allvalidchains do |t, chain, table, protocol|
       if INTERNAL_CHAINS.match?(chain)
         # can't delete internal chains
         warning "Attempting to destroy internal chain #{@resource[:name]}"
       else
-        debug "Deleting chain #{chain} on table #{table}"
+        debug "Flush chain #{chain} on table #{table} (#{protocol})"
+        t.call ['-t', table, '-F', chain]
+        debug "Deleting chain #{chain} on table #{table} (#{protocol})"
         t.call ['-t', table, '-X', chain]
       end
     end


### PR DESCRIPTION
Flush chain to get rid of unmanaged firewall rules in that chain else the remove of the chain will fail.

---

This PR fixes #1064 where you want to ensure that all unmanaged firewall chains and rules are removed but still want to be able to whitelist unmanaged rules of a chain via `ignore` or `ignore_foreign`.
Code to reproduce:
```puppet
resources { 'firewallchain':
  purge => true,
}

firewallchain { 'INPUT:filter:IPv4':
  purge  => true,
  ignore => [
    '-j fail2ban-', # ignore the fail2ban jump rule
  ],
}

firewallchain { 'fail2ban-sshd:filter:IPv4':
  purge          => true,
  ignore_foreign => true, # ignore not puppet managed rules in this chain
}
```
> **Note**: A additional `resources { 'firewall': purge => true }` is not allowed here in this case because `firewall` will else remove the normally ignored rules by `firewallchain`.
```bash
> puppet agent -t
> iptables -N test
> iptables -I test -j RETURN
> puppet agent -t
```
With this change the second puppet run will not fail and remove every unmanaged chain like this 'test' chain.
> **Note**: If there is still a reference from a rule outside of the chain that should be removed the puppet resource will fail until this reference has been removed. That means there could be still cases where multiple puppet runs are needed.

---

Fixes #1064