### PR TITLE
Ignore OpenBSD, similarly to FreeBSD

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@ class firewall (
       }
       contain "${title}::linux"
     }
-    'FreeBSD', 'windows': {
+    'FreeBSD', 'OpenBSD', 'windows': {
     }
     default: {
       fail("${title}: Kernel '${::kernel}' is not currently supported")


### PR DESCRIPTION
to prevent bailing out in case it gets pulled in by other modules.