### PR TITLE
(MAINT) Pin puppetlabs-puppet_agent

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,9 @@ fixtures:
   repositories:
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    puppet_agent: 
+      repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+      ref: v4.12.1
     provision: 'https://github.com/puppetlabs/provision.git'
   symlinks:
     "firewall": "#{source_dir}"


### PR DESCRIPTION
This change pins the puppetlabs-puppet_agent module to v4.12.1.

Previosuly, the fixutre was configured to pull from main. Given the recent changes when moving towards puppet8, main is unsafe.