### PR TITLE
(Cont 779) Add Support for Puppet 8 / Drop Support for Puppet 6

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,7 @@ fixtures:
   repositories:
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 
-      repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-      ref: v4.12.1
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     provision: 'https://github.com/puppetlabs/provision.git'
   symlinks:
     "firewall": "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
   gem "github_changelog_generator", '= 1.15.2',        require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]
+  gem "puppet_litmus", git: 'https://github.com/david22swan/puppet_litmus', branch: 'bugfix/main/puppet_8'
   gem "serverspec", '~> 2.41',    require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,9 @@ group :development do
   gem "pry", '~> 0.10',                                require: false
   gem "simplecov-console", '~> 0.5',                   require: false
   gem "puppet-debugger", '~> 1.0',                     require: false
-  gem "rubocop", '= 1.6.1',                            require: false
-  gem "rubocop-performance", '= 1.9.1',                require: false
-  gem "rubocop-rspec", '= 2.0.1',                      require: false
+  gem "rubocop", '= 1.48.1',                           require: false
+  gem "rubocop-performance", '= 1.16.0',               require: false
+  gem "rubocop-rspec", '= 2.19.0',                     require: false
   gem "rb-readline", '= 0.5.5',                        require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "github_changelog_generator", '= 1.15.2',        require: false
 end

--- a/lib/puppet/provider/firewall/iptables.rb
+++ b/lib/puppet/provider/firewall/iptables.rb
@@ -495,7 +495,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
       values.insert(ind, "-m set --match-set \"#{sets.join(';')}\" ")
     end
     # --comment can have multiple values, the same as --match-set
-    if %r{-m comment --comment}.match?(values)
+    if values.include?('-m comment --comment')
       ind = values.index('-m comment --comment')
       comments = values.scan(%r{-m comment --comment "((?:\\"|[^"])*)"})
       comments += values.scan(%r{-m comment --comment ([^"\s]+)\b})
@@ -614,7 +614,7 @@ Puppet::Type.type(:firewall).provide :iptables, parent: Puppet::Provider::Firewa
     end
 
     # manually remove comments if they made it this far
-    if %r{-m comment --comment}.match?(values)
+    if values.match?('-m comment --comment')
       values = values.sub(%r{-m comment --comment "((?:\\"|[^"])*)"}, {})
     end
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -2438,7 +2438,7 @@ Puppet::Type.newtype(:firewall) do
     end
 
     if value(:jump).to_s == 'DNAT'
-      unless %r{nat}.match?(value(:table).to_s)
+      unless value(:table).to_s.include?('nat')
         raise 'Parameter jump => DNAT only applies to table => nat'
       end
 
@@ -2448,7 +2448,7 @@ Puppet::Type.newtype(:firewall) do
     end
 
     if value(:jump).to_s == 'SNAT'
-      unless %r{nat}.match?(value(:table).to_s)
+      unless value(:table).to_s.include?('nat')
         raise 'Parameter jump => SNAT only applies to table => nat'
       end
 
@@ -2458,7 +2458,7 @@ Puppet::Type.newtype(:firewall) do
     end
 
     if value(:jump).to_s == 'MASQUERADE'
-      unless %r{nat}.match?(value(:table).to_s)
+      unless value(:table).to_s.include?('nat')
         raise 'Parameter jump => MASQUERADE only applies to table => nat'
       end
     end
@@ -2541,7 +2541,7 @@ Puppet::Type.newtype(:firewall) do
     end
 
     if value(:jump).to_s == 'CT'
-      unless %r{raw}.match?(value(:table).to_s)
+      unless value(:table).to_s.include?('raw')
         raise 'Parameter jump => CT only applies to table => raw'
       end
     end

--- a/lib/puppet/util/ipcidr.rb
+++ b/lib/puppet/util/ipcidr.rb
@@ -2,13 +2,13 @@
 
 require 'ipaddr'
 
-module Puppet::Util
+module Puppet::Util # rubocop:disable Style/ClassAndModuleChildren
   # IPCidr object wrapper for IPAddr
   class IPCidr < IPAddr
     def initialize(ipaddr, family = Socket::AF_UNSPEC)
       super(ipaddr, family)
     rescue ArgumentError => e
-      raise ArgumentError, "Invalid address from IPAddr.new: #{ipaddr}" if %r{invalid address}.match?(e.message)
+      raise ArgumentError, "Invalid address from IPAddr.new: #{ipaddr}" if e.message.include?('invalid address')
       raise e
     end
 

--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.24.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",

--- a/spec/acceptance/firewall_attributes_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_exceptions_spec.rb
@@ -561,6 +561,7 @@ describe 'firewall basics', docker: true do
             purge => true,
           }
       PUPPETCODE
+      # rubocop:disable RSpec/ExampleLength
       it 'purges only the specified chain' do
         apply_manifest(pp2, expect_changes: true)
 

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -831,6 +831,8 @@ describe firewall do # rubocop:disable RSpec/MultipleDescribes
   end
 
   describe 'autorequire packages' do
+    # rubocop:disable RSpec/ExampleLength
+    # rubocop:disable RSpec/MultipleExpectations
     [:iptables, :ip6tables].each do |provider|
       it "provider #{provider} should autorequire package iptables" do
         resource[:provider] = provider
@@ -872,6 +874,8 @@ describe firewall do # rubocop:disable RSpec/MultipleDescribes
 end
 
 describe 'firewall on unsupported platforms' do
+  let(:resource) { firewall.new(name: '000 test foo', ensure: :present) }
+
   it 'is not suitable' do
     # Stub iptables version
     allow(Facter.fact(:iptables_version)).to receive(:value).and_return(nil)
@@ -880,7 +884,6 @@ describe 'firewall on unsupported platforms' do
     # Stub confine facts
     allow(Facter.fact(:kernel)).to receive(:value).and_return('Darwin')
     allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Darwin')
-    resource = firewall.new(name: '000 test foo', ensure: :present)
 
     # If our provider list is nil, then the Puppet::Transaction#evaluate will
     # say 'Error: Could not find a suitable provider for firewall' but there


### PR DESCRIPTION
- Includes an update which pins all Rubocop versions to their newest possible version.