### PR TITLE
Fix SELinux context on newer CentOS

### DIFF
--- a/manifests/linux/redhat.pp
+++ b/manifests/linux/redhat.pp
@@ -151,6 +151,16 @@ class firewall::linux::redhat (
                 $seltype = 'system_conf_t'
               }
 
+              /^8\..*/: {
+                $seluser = 'system_u'
+                $seltype = 'etc_t'
+              }
+
+              /^9\..*/: {
+                $seluser = 'system_u'
+                $seltype = 'etc_t'
+              }
+
               default : {
                 $seluser = 'unconfined_u'
                 $seltype = 'etc_t'


### PR DESCRIPTION
Fix the SELinux contexts for CentOS Stream 8
and CentOS Stream 9.