### PR TITLE
Change ip6tables_version to constant in provider.

### DIFF
--- a/lib/puppet/provider/firewall/ip6tables.rb
+++ b/lib/puppet/provider/firewall/ip6tables.rb
@@ -52,8 +52,8 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
 
   confine kernel: :linux
 
-  ip6tables_version = Facter.value('ip6tables_version')
-  mark_flag = if ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.4.1') < 0
+  Ip6tables_version = Facter.value('ip6tables_version')
+  mark_flag = if Ip6tables_version && Puppet::Util::Package.versioncmp(Ip6tables_version, '1.4.1') < 0
                 '--set-mark'
               else
                 '--set-xmark'
@@ -61,22 +61,21 @@ Puppet::Type.type(:firewall).provide :ip6tables, parent: :iptables, source: :ip6
 
   kernelversion = Facter.value('kernelversion')
   if (kernelversion && Puppet::Util::Package.versioncmp(kernelversion, '3.13') >= 0) &&
-     (ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.6.2') >= 0)
+     (Ip6tables_version && Puppet::Util::Package.versioncmp(Ip6tables_version, '1.6.2') >= 0)
     has_feature :random_fully
   end
 
   if (kernelversion && Puppet::Util::Package.versioncmp(kernelversion, '3.3') >= 0) &&
-     (ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.4.13') >= 0)
+     (Ip6tables_version && Puppet::Util::Package.versioncmp(Ip6tables_version, '1.4.13') >= 0)
     has_feature :rpfilter
   end
 
-  if ip6tables_version && Puppet::Util::Package.versioncmp(ip6tables_version, '1.6.1') >= 0
+  if Ip6tables_version && Puppet::Util::Package.versioncmp(Ip6tables_version, '1.6.1') >= 0
     has_feature :nflog_size
   end
 
   def initialize(*args)
-    ip6tables_version = Facter.value('ip6tables_version')
-    raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if ip6tables_version&.match(%r{1\.3\.\d})
+    raise ArgumentError, 'The ip6tables provider is not supported on version 1.3 of iptables' if Ip6tables_version&.match(%r{1\.3\.\d})
     super
   end
 

--- a/spec/unit/puppet/provider/ip6tables_spec.rb
+++ b/spec/unit/puppet/provider/ip6tables_spec.rb
@@ -21,7 +21,7 @@ describe 'ip6tables' do
 
     allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
     allow(Facter.fact(:operatingsystem)).to receive(:value).and_return('Debian')
-    allow(Facter.fact('ip6tables_version')).to receive(:value).and_return(ip6tables_version)
+    stub_const('Ip6tables_version', ip6tables_version)
     allow(Puppet::Util::Execution).to receive(:execute).and_return ''
     allow(Puppet::Util).to receive(:which).with('iptables-save')
                                           .and_return '/sbin/iptables-save'


### PR DESCRIPTION
Facter is being asked for ip6tables_version every time ip6tables provider constructor is called during prefetch. This causes severe performance issues on systems with a lot of ip6tables rules (fe: openstack hypervisors) when even a single ipv6 rule is added. This commit should fix this.