### PR TITLE
[CAT-1425] : Removing RedHat/Scientific/OracleLinux 6

### DIFF
--- a/spec/acceptance/firewall_attributes_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_exceptions_spec.rb
@@ -19,9 +19,7 @@ describe 'firewall basics', docker: true do
 
   # --bytecode is only supported by operatingsystems using nftables (in general Linux kernel 3.13, RedHat 7 (and derivates) with 3.10)
   # Skipping those from which we know they would fail.
-  describe 'bytecode property', unless: (os[:family] == 'redhat' && os[:release][0] <= '6') ||
-                                        (os[:family] == 'sles' && os[:release][0..1] <= '11') ||
-                                        (fetch_os_name == 'oraclelinux' && os[:release][0] <= '7') ||
+  describe 'bytecode property', unless: (fetch_os_name == 'oraclelinux' && os[:release][0] == '7') ||
                                         (os[:family] == 'ubuntu') do
     describe 'bytecode' do
       context 'when 4,48 0 0 9,21 0 1 6,6 0 0 1,6 0 0 0' do

--- a/spec/acceptance/firewall_attributes_ipv6_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_ipv6_happy_path_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'firewall attribute testing, happy path', unless: (os[:family] == 'redhat' && os[:release].start_with?('5', '6')) || (os[:family] == 'sles') do
+describe 'firewall attribute testing, happy path', unless: (os[:family] == 'sles') do
   before :all do
     iptables_flush_all_tables
     ip6tables_flush_all_tables

--- a/spec/acceptance/resource_cmd_spec.rb
+++ b/spec/acceptance/resource_cmd_spec.rb
@@ -85,7 +85,7 @@ describe 'puppet resource firewall command' do
     end
   end
 
-  context 'when accepts rules with multiple comments', unless: (os[:family] == 'redhat' && os[:release].start_with?('5')) do
+  context 'when accepts rules with multiple comments' do
     before(:all) do
       iptables_flush_all_tables
       run_shell('iptables -A INPUT -j ACCEPT -p tcp --dport 80 -m comment --comment "http" -m comment --comment "http"')

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -62,7 +62,7 @@ RSpec.configure do |c|
   c.before :suite do
     # Depmod is not availible by default on our AlmaLinux/CentOS 8 docker image
     LitmusHelper.instance.run_shell('yum install kmod -y') if ['almalinux-8', 'centos-8'].include?("#{fetch_os_name}-#{os[:release].to_i}")
-    if ['centos-6', 'centos-7', 'oraclelinux-6', 'scientific-6', 'scientific-7'].include?("#{fetch_os_name}-#{os[:release].to_i}")
+    if ['centos-7', 'scientific-7'].include?("#{fetch_os_name}-#{os[:release].to_i}")
       LitmusHelper.instance.run_shell('yum update -y')
       LitmusHelper.instance.run_shell('depmod -a')
       ['filter', 'nat', 'mangle', 'raw'].each do |t|

--- a/spec/unit/classes/firewall_linux_spec.rb
+++ b/spec/unit/classes/firewall_linux_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'firewall::linux', type: :class do
   ['RedHat', 'CentOS'].each do |os|
     context "with Redhat Like: operatingsystem => #{os}" do
-      releases = ['6', '7', '8']
+      releases = ['7', '8']
       releases.each do |osrel|
         context "when operatingsystemrelease => #{osrel}" do
           let(:facts) do


### PR DESCRIPTION
## Summary
Removing EOL RedHat/Scientific/OracleLinux 6.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)