### PR TITLE
(GH-1164) Only common jump values should be enforced as upcase

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -863,8 +863,10 @@ class Puppet::Provider::Firewall::Firewall
       should[key][0] = ['!', should[key][0]].join(' ') if negated
     end
 
-    # `jump` values should always be uppercase
-    should[:jump] = should[:jump].upcase if should[:jump]
+    # `jump` common values should always be uppercase
+    jump_common_values = ['accept', 'reject', 'drop', 'queue', 'return', 'dnat', 'snat', 'log', 'nflog',
+                          'netmp', 'masquerade', 'redirect', 'mark', 'ct']
+    should[:jump] = should[:jump].upcase if should[:jump] && jump_common_values.include?(should[:jump].downcase)
 
     # `source` and `destination` must be put through host_to_mask
     should[:source] = PuppetX::Firewall::Utility.host_to_mask(should[:source], should[:protocol]) if should[:source]


### PR DESCRIPTION
Common jump values, depending on the OS, can be returned either as upcase or downcase values causing idempotentcy issues. This had previously been dealt with by simply enforcing upcase on all passed values. However this caused issues when passing chain's as the jump target and so the code has been update to explicitly upcase the common values only.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)