### PR TITLE
Add `tcp-reset` as an allowed option for `--reject-with`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1267,13 +1267,15 @@ Data type: `Optional[Enum['set', 'update', 'rcheck', 'remove', '! set', '! updat
 
 Data type: `Optional[Enum['icmp-net-unreachable', 'icmp-host-unreachable', 'icmp-port-unreachable', 'icmp-proto-unreachable',
                               'icmp-net-prohibited', 'icmp-host-prohibited', 'icmp-admin-prohibited', 'icmp6-no-route', 'no-route',
-                              'icmp6-adm-prohibited', 'adm-prohibited', 'icmp6-addr-unreachable', 'addr-unreach', 'icmp6-port-unreachable']]`
+                              'icmp6-adm-prohibited', 'adm-prohibited', 'icmp6-addr-unreachable', 'addr-unreach', 'icmp6-port-unreachable',
+                              'tcp-reset']]`
 
       When combined with jump => "REJECT" you can specify a different icmp response to be sent back to the packet sender.
       Valid values differ depending on if the protocol is `IPv4` or `IPv6`.
       IPv4 allows: icmp-net-unreachable, icmp-host-unreachable, icmp-port-unreachable, icmp-proto-unreachable, icmp-net-prohibited,
-      icmp-host-prohibited, or icmp-admin-prohibited.
-      IPv6 allows: icmp6-no-route, no-route, icmp6-adm-prohibited, adm-prohibited, icmp6-addr-unreachable, addr-unreach, or icmp6-port-unreachable.
+      icmp-host-prohibited, icmp-admin-prohibited, or tcp-reset.
+      IPv6 allows: icmp6-no-route, no-route, icmp6-adm-prohibited, adm-prohibited, icmp6-addr-unreachable, addr-unreach,
+      icmp6-port-unreachable, or tcp-reset.
 
 ##### `rhitcount`
 

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1261,13 +1261,15 @@ Puppet::ResourceApi.register_type(
     reject: {
       type: "Optional[Enum['icmp-net-unreachable', 'icmp-host-unreachable', 'icmp-port-unreachable', 'icmp-proto-unreachable',
                               'icmp-net-prohibited', 'icmp-host-prohibited', 'icmp-admin-prohibited', 'icmp6-no-route', 'no-route',
-                              'icmp6-adm-prohibited', 'adm-prohibited', 'icmp6-addr-unreachable', 'addr-unreach', 'icmp6-port-unreachable']]",
+                              'icmp6-adm-prohibited', 'adm-prohibited', 'icmp6-addr-unreachable', 'addr-unreach', 'icmp6-port-unreachable',
+                              'tcp-reset']]",
       desc: <<-DESC
       When combined with jump => "REJECT" you can specify a different icmp response to be sent back to the packet sender.
       Valid values differ depending on if the protocol is `IPv4` or `IPv6`.
       IPv4 allows: icmp-net-unreachable, icmp-host-unreachable, icmp-port-unreachable, icmp-proto-unreachable, icmp-net-prohibited,
-      icmp-host-prohibited, or icmp-admin-prohibited.
-      IPv6 allows: icmp6-no-route, no-route, icmp6-adm-prohibited, adm-prohibited, icmp6-addr-unreachable, addr-unreach, or icmp6-port-unreachable.
+      icmp-host-prohibited, icmp-admin-prohibited, or tcp-reset.
+      IPv6 allows: icmp6-no-route, no-route, icmp6-adm-prohibited, adm-prohibited, icmp6-addr-unreachable, addr-unreach,
+      icmp6-port-unreachable, or tcp-reset.
       DESC
     },
     set_mark: {

--- a/spec/acceptance/firewall_attributes_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_happy_path_spec.rb
@@ -239,6 +239,12 @@ describe 'firewall attribute testing, happy path' do
             chain     => 'FORWARD',
             table     => 'mangle',
           }
+          firewall { '605 - reject with tcp-reset':
+            proto  => tcp,
+            jump   => reject,
+            reject => 'tcp-reset',
+          }
+
           firewall { '700 - blah-A Test Rule':
             jump       => 'LOG',
             log_prefix => 'FW-A-INPUT: ',
@@ -475,6 +481,10 @@ describe 'firewall attribute testing, happy path' do
 
     it 'set_mss is set' do
       expect(result.stdout).to match(%r{-A FORWARD -p (tcp|6) -m tcp --tcp-flags SYN,RST SYN -m tcpmss --mss 1361:1541 -m comment --comment "604 - set_mss" -j TCPMSS --set-mss 1360})
+    end
+
+    it 'tcp-reset is set' do
+      expect(result.stdout).to match(%r{-A INPUT -p (tcp|6) -m comment --comment "605 - reject with tcp-reset" -j REJECT --reject-with tcp-reset})
     end
 
     it 'clamp_mss_to_pmtu is set' do

--- a/spec/acceptance/firewall_attributes_ipv6_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_ipv6_happy_path_spec.rb
@@ -217,6 +217,12 @@ describe 'firewall attribute testing, happy path', unless: (os[:family] == 'sles
           src_type => ['LOCAL', '! LOCAL'],
           protocol => 'ip6tables',
         }
+        firewall { '621 - reject with tcp-reset':
+          proto    => tcp,
+          jump     => reject,
+          reject   => 'tcp-reset',
+          protocol => 'ip6tables',
+        }
         firewall { '801 - ipt_modules tests':
           proto              => tcp,
           dport              => '8080',
@@ -394,6 +400,10 @@ describe 'firewall attribute testing, happy path', unless: (os[:family] == 'sles
 
     it 'src_type when multiple values' do
       expect(result.stdout).to match(%r{-A INPUT -p (tcp|6) -m addrtype --src-type LOCAL -m addrtype ! --src-type LOCAL -m comment --comment "620 - src_type multiple values" -j ACCEPT})
+    end
+
+    it 'tcp-reset is set' do
+      expect(result.stdout).to match(%r{-A INPUT -p (tcp|6) -m comment --comment "621 - reject with tcp-reset" -j REJECT --reject-with tcp-reset})
     end
 
     it 'all the modules with multiple args is set' do


### PR DESCRIPTION
## Summary
Allows `--reject-with tcp-reset`.  This was allowed before the 7.0 rewrite, but lost and a regression introduced in that cutover.

`tcp-reset` is allowed (`man 8 iptables-extensions`) since ancient kernel 2.6.14, and is valid on TCP-matching rules.  There's no "you can only do this on TCP rules" limitation included in this PR, as it's valid to do (INPUT rule that matches TCP should jump to Xchain) -> (Xchain does a reject without declaring/knowing that it's TCP).

## Additional Context

## Related Issues (if any)
Resolves #1184

## Checklist
- [ ] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)