### PR TITLE
(CAT-1746) - Ubuntu ARM spec failure fixes

### DIFF
--- a/spec/acceptance/resource_cmd_spec.rb
+++ b/spec/acceptance/resource_cmd_spec.rb
@@ -20,7 +20,7 @@ describe 'puppet resource firewall command' do
       run_shell('source /etc/profile.d/my-custom.lang.sh')
     end
     run_shell('echo export LC_ALL="C" >> ~/.bashrc')
-    run_shell('source ~/.bashrc')
+    run_shell('source ~/.bashrc || true')
   end
 
   context 'when make sure it returns no errors when executed on a clean machine' do


### PR DESCRIPTION
## Summary

While loading user profile, source command is not available for Ubuntu ARM which leads to spec failures.


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)