### PR TITLE
Allow a singular numeric port for the `--to-ports` parameter

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1189,7 +1189,7 @@ Puppet::ResourceApi.register_type(
       DESC
     },
     toports: {
-      type: 'Optional[Pattern[/^\d+(?:-\d+)?$/]]',
+      type: 'Optional[Variant[Integer[0, 65535], Pattern[/^\d+(?:-\d+)?$/]]]',
       desc: <<-DESC
       For REDIRECT/MASQUERADE this is the port that will replace the destination/source port.
       Can specify a single new port or an inclusive range of ports.

--- a/spec/acceptance/firewall_attributes_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_happy_path_spec.rb
@@ -144,6 +144,13 @@ describe 'firewall attribute testing, happy path' do
             jump    => 'REDIRECT',
             toports => '2222',
           }
+          firewall { '575 - toports-numeric':
+            proto   => icmp,
+            table   => 'nat',
+            chain   => 'PREROUTING',
+            jump    => 'REDIRECT',
+            toports => 3333,
+          }
           firewall { '581 - pkttype':
             ensure  => present,
             proto   => tcp,
@@ -439,6 +446,10 @@ describe 'firewall attribute testing, happy path' do
 
     it 'toports is set' do
       expect(result.stdout).to match(%r{-A PREROUTING -p (icmp|1) -m comment --comment "574 - toports" -j REDIRECT --to-ports 2222})
+    end
+
+    it 'toports-numeric is set' do
+      expect(result.stdout).to match(%r{-A PREROUTING -p (icmp|1) -m comment --comment "575 - toports-numeric" -j REDIRECT --to-ports 3333})
     end
 
     it 'rpfilter is set' do

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -507,9 +507,9 @@ RSpec.describe 'firewall type' do
                 { name: '001 test rule', tosource: 313 }]
     },
     ':toports': {
-      valid: [{ name: '001 test rule', toports: '40' }, { name: '001 test rule', tosource: '50-60' }],
-      invalid: [{ name: '001 test rule', toports: 'invalid' }, { name: '001 test rule', toports: false },
-                { name: '001 test rule', toports: 313 }]
+      valid: [{ name: '001 test rule', toports: '40' }, { name: '001 test rule', tosource: '50-60' },
+              { name: '001 test rule', toports: 313 }],
+      invalid: [{ name: '001 test rule', toports: 'invalid' }, { name: '001 test rule', toports: false }]
     },
     ':to': {
       valid: [{ name: '001 test rule', to: '10.0.0.2' }, { name: '001 test rule', to: '10.0.0.2/24' }],


### PR DESCRIPTION
## Summary
Allows a numeric port for `--to-ports` / `firewall.toports`

## Additional Context
`Variant[Integer[0, 65535]` is Stdlib::Port, but using that fails with "firewall.toports references an unresolved type 'Stdlib::Port'" so oh well.
- [ ] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)
Resolves #1186

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)