### PR TITLE
(MODULES-11449) - Fix for IPv6 NAT chain

### DIFF
--- a/lib/puppet/provider/firewallchain/firewallchain.rb
+++ b/lib/puppet/provider/firewallchain/firewallchain.rb
@@ -172,7 +172,6 @@ class Puppet::Provider::Firewallchain::Firewallchain
       raise ArgumentError, 'PREROUTING, POSTROUTING, INPUT, FORWARD and OUTPUT are the only inbuilt chains that can be used in table \'mangle\'' if %r{^(BROUTING)$}.match?(should[:chain])
     when 'nat'
       raise ArgumentError, 'PREROUTING, POSTROUTING, INPUT, and OUTPUT are the only inbuilt chains that can be used in table \'nat\'' if %r{^(BROUTING|FORWARD)$}.match?(should[:chain])
-      raise ArgumentError, 'table nat isn\'t valid in IPv6. You must specify \':IPv4\' as the name suffix' if %r{^(IP(v6)?)?$}.match?(should[:protocol])
     when 'raw'
       raise ArgumentError, 'PREROUTING and OUTPUT are the only inbuilt chains in the table \'raw\'' if %r{^(POSTROUTING|BROUTING|INPUT|FORWARD)$}.match?(should[:chain])
     when 'broute'

--- a/spec/acceptance/firewallchain_spec.rb
+++ b/spec/acceptance/firewallchain_spec.rb
@@ -82,6 +82,18 @@ describe 'puppet resource firewallchain command' do
         end
       end
     end
+
+    context 'with NAT chain' do
+      pp3 = <<-PUPPETCODE
+          firewallchain { 'MY_CHAIN:nat:IPv6':
+            ensure  => present,
+          }
+      PUPPETCODE
+      it 'applies cleanly' do
+        # Run it twice and test for idempotency
+        idempotent_apply(pp3)
+      end
+    end
   end
 
   # XXX purge => false is not yet implemented

--- a/spec/unit/puppet/provider/firewallchain/firewallchain_spec.rb
+++ b/spec/unit/puppet/provider/firewallchain/firewallchain_spec.rb
@@ -317,10 +317,6 @@ COMMIT
           error: 'PREROUTING, POSTROUTING, INPUT, and OUTPUT are the only inbuilt chains that can be used in table \'nat\''
         },
         {
-          should: { name: 'PREROUTING:nat:IPv6', chain: 'PREROUTING', table: 'nat', protocol: 'IPv6', ensure: 'present', policy: 'accept' },
-          error: 'table nat isn\'t valid in IPv6. You must specify \':IPv4\' as the name suffix'
-        },
-        {
           should: { name: 'INPUT:raw:IPv4', chain: 'INPUT', table: 'raw', protocol: 'IPv4', ensure: 'present', policy: 'accept' },
           error: 'PREROUTING and OUTPUT are the only inbuilt chains in the table \'raw\''
         },


### PR DESCRIPTION
## Summary

Fixing the creation of firewall chai for IPv6 with nat table.


## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)