### PR TITLE
Fix resource generation ipcidr dependency

### DIFF
--- a/lib/puppet_x/puppetlabs/firewall/utility.rb
+++ b/lib/puppet_x/puppetlabs/firewall/utility.rb
@@ -3,7 +3,7 @@
 require 'puppet_x'
 require 'socket'
 require 'resolv'
-require 'puppet_x/puppetlabs/firewall/ipcidr'
+require_relative 'ipcidr'
 
 module PuppetX::Firewall # rubocop:disable Style/ClassAndModuleChildren
   # A utility class meant to contain re-usable code


### PR DESCRIPTION
## Summary
This change should fix partial issue with resource generation:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/firewallchain: Could not autoload puppet/provider/firewallchain/firewallchain: no such file to load -- puppet_x/puppetlabs/firewall/ipcidr (file: /etc/puppetlabs/code/puppet-control/dev/profile_modules/profile/manifests/example/sample.pp, line: 40, column: 3) on node host.example.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

You still need to do manual steps after upgrading from the previous version:

1. Find and delete firewall-related cache
`find $(puppet config print vardir) -ipath '*firewall*' -type f -delete`
2. Regenerate resource types 
`puppet generate types --environment <environment>`

## Additional Context
As far as i understand puppet tries to load providers and types from the previous version that he keeps in his cache. This problem especially tricky if you have multiple environments and are trying to test new version in a non-default one. I was forced to create separate puppetserver instance to properly test all the changes. 

## Related Issues (if any)
Related to #1162 