### PR TITLE
Allow -_ in ipset name

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -879,7 +879,7 @@ Data type: `Optional[Enum['none', 'ipsec']]`
 
 ##### `ipset`
 
-Data type: `Optional[Variant[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/]]]]`
+Data type: `Optional[Variant[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/]]]]`
 _*this data type contains a regex that may not be accurately reflected in generated documentation_
 
       Matches against the specified ipset list.

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -948,8 +948,7 @@ Puppet::ResourceApi.register_type(
       DESC
     },
     ipset: {
-      type: 'Optional[Variant[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/]]]]',
-      desc: <<-DESC
+      type: 'Optional[Variant[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/]]]]',      desc: <<-DESC
       Matches against the specified ipset list.
       Requires ipset kernel module. Will accept a single element or an array.
       The value is the name of the denylist, followed by a space, and then


### PR DESCRIPTION
## Summary
Allow setting a `-` and `_` in ipset name

Should fix #1187 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)