### PR TITLE
Single element ipset array should be in sync with its string equivalent

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -444,6 +444,12 @@ class Puppet::Provider::Firewall::Firewall
       should = should_hash[property_name].to_s.gsub(%r{\s+}, '')
 
       is == should
+    when :ipset
+      is = is_hash[property_name]
+      is = [is] if is.is_a?(String)
+      should = should_hash[property_name]
+      should = [should] if should.is_a?(String)
+      is.sort == should.sort
     else
       # Ensure that if both values are arrays, that they are sorted prior to comparison
       return nil unless is_hash[property_name].is_a?(Array) && should_hash[property_name].is_a?(Array)


### PR DESCRIPTION
## Summary
Currently if you have a single value `ipset` parameter it will always be trying to correct itself on every puppet run.

## Additional info
I tried to create proper acceptance test for this case but it requires installed `ipset` package with created ipsets for testing so i decided not to do it.
## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)