### PR TITLE
Port ranges as string with hyphen as range indicator should work

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -443,8 +443,6 @@ class Puppet::Provider::Firewall::Firewall
         should = should.tr('-', ':') if ports.include?(property_name)
 
         is == should
-      else
-        return nil
       end
     when :string_hex
       # Compare the values with any whitespace removed

--- a/spec/acceptance/firewall_attributes_exceptions_spec.rb
+++ b/spec/acceptance/firewall_attributes_exceptions_spec.rb
@@ -68,6 +68,21 @@ describe 'firewall basics', docker: true do
         end
       end
     end
+
+    context 'when port range as a string' do
+      pp23 = <<-PUPPETCODE
+          class { '::firewall': }
+          firewall { '562 - test port range':
+            proto  => tcp,
+            dport  => '561-570',
+            jump   => accept,
+          }
+      PUPPETCODE
+      it 'applies' do
+        idempotent_apply(pp23)
+        apply_manifest(pp23, catch_changes: true)
+      end
+    end
   end
 
   describe 'ensure' do
@@ -650,6 +665,21 @@ describe 'firewall basics', docker: true do
         run_shell('iptables-save') do |r|
           expect(r.stdout).not_to match(%r{-A INPUT -p (tcp|6) -m tcp --sport 9999560-561 -m comment --comment "560 - test" -j ACCEPT})
         end
+      end
+    end
+
+    context 'when port range as a string' do
+      pp20 = <<-PUPPETCODE
+          class { '::firewall': }
+          firewall { '561 - test port range':
+            proto  => tcp,
+            sport  => '561-570',
+            jump   => accept,
+          }
+      PUPPETCODE
+      it 'applies' do
+        idempotent_apply(pp20)
+        apply_manifest(pp20, catch_changes: true)
       end
     end
   end

--- a/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
+++ b/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
           { is_hash: { mac_source: '! 0A:1B:3C:4D:5E:6F' }, should_hash: { mac_source: '0A:1B:3C:4D:5E:6F' }, result: false },
         ] },
         { testing: 'state/ctstate/ctstatus', property_name: :state, comparisons: [
-          { is_hash: { state: 'NEW' }, should_hash: { state: 'NEW' }, result: nil },
+          { is_hash: { state: 'NEW' }, should_hash: { state: 'NEW' }, result: true },
           { is_hash: { state: ['NEW'] }, should_hash: { state: 'NEW' }, result: nil },
           { is_hash: { state: 'NEW' }, should_hash: { state: ['NEW', 'INVALID'] }, result: nil },
           { is_hash: { state: ['INVALID', 'NEW'] }, should_hash: { state: ['NEW', 'INVALID'] }, result: true },
@@ -201,7 +201,7 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
           { is_hash: { jump: 'accept' }, should_hash: { jump: 'drop' }, result: false },
         ] },
         { testing: 'dport/sport', property_name: :dport, comparisons: [
-          { is_hash: { dport: '50' }, should_hash: { dport: '50' }, result: nil },
+          { is_hash: { dport: '50' }, should_hash: { dport: '50' }, result: true },
           { is_hash: { dport: ['50:60'] }, should_hash: { dport: '50-60' }, result: nil },
           { is_hash: { dport: ['50:60'] }, should_hash: { dport: ['50-60'] }, result: true },
           { is_hash: { dport: ['! 50:60', '90'] }, should_hash: { dport: ['! 90', '! 50-60'] }, result: true },


### PR DESCRIPTION
## Summary
If you set `dport|sport` values as a string with `-` as range indicator puppet will be applying manifest on every run.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)