### PR TITLE
Allow explicitly set default log_level

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -995,8 +995,7 @@ Data type: `Optional[Variant[Integer[0,7],String[1]]]`
 
       When combined with jump => "LOG" specifies the system log level to log to.
 
-      Note: log level 4/warn is the default setting and as such it is not returned by iptables-save.
-      As a result, explicitly setting `log_level` to this can result in idempotency errors.
+      Note: log level 4/warn is the default setting.
 
 ##### `log_prefix`
 

--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -189,6 +189,11 @@ class Puppet::Provider::Firewall::Firewall
     :time_contiguous, :kernel_timezone, :clusterip_new, :queue_bypass, :ipvs, :notrack
   ]
 
+  # These are known resources that is omitted from the output of iptables-save if default value is set.
+  $known_omitted_defaults = [
+    :log_level
+  ]
+
   # Properties that use "-m <ipt module name>" (with the potential to have multiple
   # arguments against the same IPT module) must be in this hash. The keys in this
   # hash are the IPT module names, with the values being an array of the respective
@@ -326,7 +331,7 @@ class Puppet::Provider::Firewall::Firewall
     context.debug("Checking whether '#{property_name}' is out of sync")
 
     # If either value is nil, no custom logic is required
-    return nil if is_hash[property_name].nil? || should_hash[property_name].nil?
+    return nil if (is_hash[property_name].nil? || should_hash[property_name].nil?) && !$known_omitted_defaults.include?(property_name)
 
     case property_name
     when :protocol

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1230,8 +1230,7 @@ Puppet::ResourceApi.register_type(
       desc: <<-DESC
       When combined with jump => "LOG" specifies the system log level to log to.
 
-      Note: log level 4/warn is the default setting and as such it is not returned by iptables-save.
-      As a result, explicitly setting `log_level` to this can result in idempotency errors.
+      Note: log level 4/warn is the default setting.
       DESC
     },
     log_uid: {

--- a/lib/puppet_x/puppetlabs/firewall/utility.rb
+++ b/lib/puppet_x/puppetlabs/firewall/utility.rb
@@ -197,6 +197,7 @@ module PuppetX::Firewall # rubocop:disable Style/ClassAndModuleChildren
         when 'not', 'notice' then '5'
         when 'info' then '6'
         when 'debug' then '7'
+        when nil then '4'
         else nil
         end
       end


### PR DESCRIPTION
## Summary
You should be able to set default log_level (4) explicitly in a rule. Currently puppet will apply "changes" every run.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)