### PR TITLE
nfmask, ctmask, restore_mark support + firewallchain loop fix

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -74,6 +74,7 @@ class Puppet::Provider::Firewall::Firewall
     ipsec_dir: '--dir',
     ipsec_policy: '--pol',
     state: '--state',
+    ctmask: '--ctmask',
     ctstate: '--ctstate',
     ctproto: '--ctproto',
     ctorigsrc: '--ctorigsrc',
@@ -122,6 +123,7 @@ class Puppet::Provider::Firewall::Firewall
     nflog_range: '--nflog-range',
     nflog_size: '--nflog-size',
     nflog_threshold: '--nflog-threshold',
+    nfmask: '--nfmask',
     gateway: '--gateway',
     clamp_mss_to_pmtu: '--clamp-mss-to-pmtu',
     set_mss: '--set-mss',
@@ -141,6 +143,7 @@ class Puppet::Provider::Firewall::Firewall
     log_tcp_options: '--log-tcp-options',
     log_ip_options: '--log-ip-options',
     reject: '--reject-with',
+    restore_mark: '--restore-mark',
     set_mark: '--set-xmark',
     match_mark: '-m mark --mark',
     mss: '-m tcpmss --mss',
@@ -186,7 +189,7 @@ class Puppet::Provider::Firewall::Firewall
     :checksum_fill, :clamp_mss_to_pmtu, :isfragment, :ishasmorefrags, :islastfrag, :isfirstfrag,
     :log_uid, :log_tcp_sequence, :log_tcp_options, :log_ip_options, :random_fully, :random,
     :rdest, :reap, :rsource, :rttl, :socket, :physdev_is_bridged, :physdev_is_in, :physdev_is_out,
-    :time_contiguous, :kernel_timezone, :clusterip_new, :queue_bypass, :ipvs, :notrack
+    :time_contiguous, :kernel_timezone, :clusterip_new, :queue_bypass, :ipvs, :notrack, :restore_mark
   ]
 
   # Properties that use "-m <ipt module name>" (with the potential to have multiple
@@ -244,7 +247,7 @@ class Puppet::Provider::Firewall::Firewall
     :clusterip_clustermac, :clusterip_total_nodes, :clusterip_local_node, :clusterip_hash_init, :queue_num, :queue_bypass,
     :nflog_group, :nflog_prefix, :nflog_range, :nflog_size, :nflog_threshold, :clamp_mss_to_pmtu, :gateway,
     :set_mss, :set_dscp, :set_dscp_class, :todest, :tosource, :toports, :to, :checksum_fill, :random_fully, :random, :log_prefix,
-    :log_level, :log_uid, :log_tcp_sequence, :log_tcp_options, :log_ip_options, :reject, :set_mark, :match_mark, :mss,
+    :log_level, :log_uid, :log_tcp_sequence, :log_tcp_options, :log_ip_options, :reject, :set_mark, :match_mark, :restore_mark, :nfmask, :ctmask, :mss,
     :connlimit_upto, :connlimit_above, :connlimit_mask, :connmark,
     :time_start, :time_stop, :month_days, :week_days, :date_start, :date_stop, :time_contiguous, :kernel_timezone,
     :u32, :src_cc, :dst_cc, :hashlimit_upto, :hashlimit_above, :hashlimit_name, :hashlimit_burst,

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -593,6 +593,18 @@ Puppet::ResourceApi.register_type(
         In order to maintain compatibility it is also possible to negate all values given in the array to achieve the same behaviour.
       DESC
     },
+    ctmask: {
+      type: 'Optional[String]',
+      desc: <<-DESC
+      ctmask
+      DESC
+    },
+    nfmask: {
+      type: 'Optional[String]',
+      desc: <<-DESC
+      nfmask
+      DESC
+    },
     ctstate: {
       type: 'Optional[Variant[Pattern[/^(?:!\s)?(?:INVALID|ESTABLISHED|NEW|RELATED|UNTRACKED|SNAT|DNAT)$/], Array[Pattern[/^(?:!\s)?(?:INVALID|ESTABLISHED|NEW|RELATED|UNTRACKED|SNAT|DNAT)$/]]]]',
       desc: <<-DESC
@@ -1269,6 +1281,12 @@ Puppet::ResourceApi.register_type(
       icmp-host-prohibited, icmp-admin-prohibited, or tcp-reset.
       IPv6 allows: icmp6-no-route, no-route, icmp6-adm-prohibited, adm-prohibited, icmp6-addr-unreachable, addr-unreach,
       icmp6-port-unreachable, or tcp-reset.
+      DESC
+    },
+    restore_mark: {
+      type: 'Optional[Boolean]',
+      desc: <<-DESC
+      Whether or not to restore mark.
       DESC
     },
     set_mark: {


### PR DESCRIPTION
## Summary
We have been using our custom version of puppetlabs-firewall for some time because we need the nfmask, ctmask and restore_mark flags for policy based routing.

While upgrading to the latest puppetlabs-firewall, I ran into an infinite loop, creating chains all of a sudden.
As per the docs, I've written this Puppet code:
```
  # Purge all chains not defined below
  resources { 'firewallchain':
    purge  => true,
  }

  # Purge all unmanaged rules from these (internal) chains
  # These have default policy DROP
  firewallchain {
    [
      'INPUT:filter:IPv4',
      'INPUT:filter:IPv6',
      'OUTPUT:filter:IPv4',
      'OUTPUT:filter:IPv6',
      'FORWARD:filter:IPv4',
      'FORWARD:filter:IPv6']:
        ensure => present,
        policy => drop,
        purge  => true,
  }

  # The internal chains need to be defined or Puppet will try to remove them.
  # We can also purge their contents by defining them here with purge => true.
  firewallchain {
    [
      # IPv4 mangle
      'PREROUTING:mangle:IPv4',
      'INPUT:mangle:IPv4',
      'FORWARD:mangle:IPv4',
      'OUTPUT:mangle:IPv4',
      'POSTROUTING:mangle:IPv4',
      # IPv6 mangle
      'PREROUTING:mangle:IPv6',
      'INPUT:mangle:IPv6',
...and so forth
```
Because iptables-save doesn't always show chains like *nat or *mangle if they haven't been interacted with, the `get` function will not return those and puppetlabs-firewall will try to create the chains. However, this won't do anything and the infinite loop starts.

I have 'solved' it by creating those chains manually for now and only adding them if the already existing code didn't find them.

I have verified that these changes solve my issue and that nfmask, ctmask and restore_mark work.

Because this actually is an issue that I imagine others will run into, I decided to create the PR, regardless of code quality, lack of context and knowledge.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)