### PR TITLE
(CAT-2088): Fix for not rejecting valid iptables

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -879,7 +879,7 @@ Data type: `Optional[Enum['none', 'ipsec']]`
 
 ##### `ipset`
 
-Data type: `Optional[Variant[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/]]]]`
+Data type: `Optional[Variant[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/]]]]`
 _*this data type contains a regex that may not be accurately reflected in generated documentation_
 
       Matches against the specified ipset list.

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -948,7 +948,7 @@ Puppet::ResourceApi.register_type(
       DESC
     },
     ipset: {
-      type: 'Optional[Variant[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?\w+\s(?:src|dst)(?:,src|,dst)?$/]]]]',
+      type: 'Optional[Variant[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?[\w\-_]+\s(?:src|dst)(?:,src|,dst)?$/]]]]',
       desc: <<-DESC
       Matches against the specified ipset list.
       Requires ipset kernel module. Will accept a single element or an array.


### PR DESCRIPTION
Fix for not rejecting valid iptables:
1. Allow -_ in ipset name