### PR TITLE
Query gid to prevent errors with missing users with the same id (fixes #1229)

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -376,9 +376,16 @@ class Puppet::Provider::Firewall::Firewall
       end
 
       # If 'is' or 'should' contain anything other than digits or digit range,
-      # we assume that we have to do a lookup to convert to UID
-      is = Etc.getpwnam(is).uid unless is[%r{[0-9]+(-[0-9]+)?}] == is
-      should = Etc.getpwnam(should).uid unless should[%r{[0-9]+(-[0-9]+)?}] == should
+      # we assume that we have to do a lookup to convert to UID or GID
+      if property_name == :uid
+        is = Etc.getpwnam(is).uid unless is[%r{[0-9]+(-[0-9]+)?}] == is
+        should = Etc.getpwnam(should).uid unless should[%r{[0-9]+(-[0-9]+)?}] == should
+      end
+
+      if property_name == :gid
+        is = Etc.getgrnam(is).gid unless is[%r{[0-9]+(-[0-9]+)?}] == is
+        should = Etc.getgrnam(should).gid unless should[%r{[0-9]+(-[0-9]+)?}] == should
+      end
 
       "#{is_negate}#{is}" == "#{should_negate}#{should}"
     when :mac_source, :jump

--- a/spec/acceptance/firewall_attributes_happy_path_spec.rb
+++ b/spec/acceptance/firewall_attributes_happy_path_spec.rb
@@ -12,6 +12,9 @@ describe 'firewall attribute testing, happy path' do
   describe 'attributes test' do
     before(:all) do
       pp = <<-PUPPETCODE
+          group { 'testgroup':
+            gid => '1234',
+          }
           class { '::firewall': }
           firewall { '004 - log_level and log_prefix':
             chain      => 'INPUT',
@@ -291,6 +294,12 @@ describe 'firewall attribute testing, happy path' do
             chain => 'OUTPUT',
             jump  => accept,
             gid   => 'root',
+            proto => 'all',
+          }
+          firewall { '801 - gid testgroup':
+            chain => 'OUTPUT',
+            jump  => accept,
+            gid   => 'testgroup',
             proto => 'all',
           }
           firewall { '802 - gid root negated':


### PR DESCRIPTION
## Summary
If a firewall rule is assigned to a group and the same user does not exist, then we get an error:

```
Error: /Stage[main]/Main/Firewall[801 - gid testgroup]/gid: change from '1234' to 'testgroup' failed: can't find user for testgroup
```

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)