### PR TITLE
Fix managing build-in chain on iptables nft

### DIFF
--- a/lib/puppet/provider/firewallchain/firewallchain.rb
+++ b/lib/puppet/provider/firewallchain/firewallchain.rb
@@ -34,10 +34,6 @@ class Puppet::Provider::Firewallchain::Firewallchain
   $chain_delete_command = '-X'
   # Command to set chain policy, works on inbuilt chains only
   $chain_policy_command = '-P'
-  # Command to list specific table so it will generate necessary output for iptables-save
-  # The retrieval of in-built chains may get confused by `iptables-save` tendency to not return table information
-  # for tables that have not yet been interacted with.
-  $table_list_command = '-L'
   # Check if the given chain name references a built in one
   $built_in_regex = %r{^(?:INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING)$}
 
@@ -104,7 +100,7 @@ class Puppet::Provider::Firewallchain::Firewallchain
     context.notice("Creating Chain '#{name}' with #{should.inspect}")
     # If a built-in chain is not present we assume that corresponding table has not been interacted with
     if $built_in_regex.match(should[:chain])
-      Puppet::Provider.execute([$base_command[should[:protocol]], should[:table], $table_list_command].join(' '))
+      Puppet::Provider.execute([$base_command[should[:protocol]], should[:table], $chain_policy_command, should[:chain], should[:policy].upcase].join(' '))
     else
       Puppet::Provider.execute([$base_command[should[:protocol]], should[:table], $chain_create_command, should[:chain]].join(' '))
     end


### PR DESCRIPTION
`iptables-save` does not show any build-in chains when they have not been interacted with. This leads to the chain being (re)-created.

#1206 attempted to fix this, by listing the chain instead of creating it, but this method only seems to work on non-nft iptables (https://github.com/puppetlabs/puppetlabs-firewall/issues/1217#issuecomment-2130211647).

Fix this for nft version of iptables by setting the policy of the chain instead of listing it. This seems to work for both nft and non-nft version of iptables (tested on Ubuntu 20.04 and 24.04).

Fixes #1217

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)