### PR TITLE
(MODULES-11580) Do not combine stderr and stdout when scanning rules

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -472,7 +472,7 @@ class Puppet::Provider::Firewall::Firewall
     # For each protocol
     protocols.each do |protocol|
       # Retrieve String containing all information
-      iptables_list = Puppet::Provider.execute($list_command[protocol])
+      iptables_list = Puppet::Provider.execute($list_command[protocol], combine: false, failonfail: true)
       # Scan String to retrieve all Rules
       iptables_list.scan($table_regex).each do |table|
         table_name = table[0].scan($table_name_regex)[0][0]

--- a/spec/unit/puppet/provider/firewall/firewall_output_parsing_spec.rb
+++ b/spec/unit/puppet/provider/firewall/firewall_output_parsing_spec.rb
@@ -344,8 +344,8 @@ COMMIT
       end
 
       it 'processes the resource' do
-        allow(Puppet::Util::Execution).to receive(:execute).with('iptables-save').and_return(iptables)
-        allow(Puppet::Util::Execution).to receive(:execute).with('ip6tables-save').and_return(ip6tables)
+        allow(Puppet::Util::Execution).to receive(:execute).with('iptables-save', { combine: false, failonfail: true }).and_return(iptables)
+        allow(Puppet::Util::Execution).to receive(:execute).with('ip6tables-save', { combine: false, failonfail: true }).and_return(ip6tables)
 
         expect(provider.get(context)).to eq(returned_data)
       end

--- a/spec/unit/puppet/provider/firewallchain/firewallchain_spec.rb
+++ b/spec/unit/puppet/provider/firewallchain/firewallchain_spec.rb
@@ -326,8 +326,8 @@ COMMIT
         },
       ].each do |test|
         before(:each) do
-          allow(Puppet::Util::Execution).to receive(:execute).with('iptables-save').and_return(iptables)
-          allow(Puppet::Util::Execution).to receive(:execute).with('ip6tables-save').and_return(ip6tables)
+          allow(Puppet::Util::Execution).to receive(:execute).with('iptables-save', { combine: false, failonfail: true }).and_return(iptables)
+          allow(Puppet::Util::Execution).to receive(:execute).with('ip6tables-save', { combine: false, failonfail: true }).and_return(ip6tables)
         end
 
         it "purge chain: '#{test[:should]}'" do


### PR DESCRIPTION
## Summary
 - We get the output of 'ip(6)tables-save' and parse the contents to get the iptables rules.
 - When stderr is combined with stdout, the output of the command can be unexpected causing issues when parsing.
 - This commit disables the combination of stdout and stderr for this reason.
 - Setting 'failonfail' makes sure that any error returned by 'ip(6)tables-save' command is reported as failure to the user without attempting to parse its output.

## Additional Context

## Related Issues (if any)


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)