### PR TITLE
(CAT-2642) Add fork CI label guard and gate acceptance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,31 @@ on:
   pull_request:
     branches:
       - "main"
+  pull_request_target:
+    types: [labeled, reopened]
+    branches:
+      - "main"
   workflow_dispatch:
-    
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Spec:
+    if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
-    secrets: "inherit"
 
   Acceptance:
-    needs: Spec
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.fork == true &&
+       contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
-    with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7 --platform-exclude centos-8 --platform-exclude rocky-8"
     secrets: "inherit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,6 @@ jobs:
        github.event.pull_request.head.repo.fork == true &&
        contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7 --platform-exclude centos-8 --platform-exclude rocky-8"
     secrets: "inherit"

--- a/.github/workflows/fork_ci_label_guard.yml
+++ b/.github/workflows/fork_ci_label_guard.yml
@@ -1,0 +1,12 @@
+name: "Fork CI Label Guard"
+
+on:
+  pull_request_target:
+    types: [synchronize, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  strip:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@main"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -732,6 +732,3 @@ Style/StringChars:
   Enabled: false
 Style/SwapValues:
   Enabled: false
-RSpec/SpecFilePathFormat:
-  Exclude:
-  - spec/unit/puppet_x/puppetlabs/**/*_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -732,3 +732,6 @@ Style/StringChars:
   Enabled: false
 Style/SwapValues:
   Enabled: false
+RSpec/SpecFilePathFormat:
+  Exclude:
+  - spec/unit/puppet_x/puppetlabs/**/*_spec.rb

--- a/metadata.json
+++ b/metadata.json
@@ -85,6 +85,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g1514103",
+  "template-ref": "heads/main-0-gcd0953f",
   "pdk-version": "3.7.0"
 }


### PR DESCRIPTION
Consume latest pdk-templates.

Add a pull_request_target trigger so acceptance tests can run on forked PRs only when an 'allowed-for-ci' label is present, and add a Fork CI Label Guard workflow to strip the label on synchronize/close. Also sync PDK template-ref and drop the obsolete RSpec/SpecFilePathFormat override.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)