### PR TITLE
(bugfix) Fix log_level idempotency when explicitly setting the iptables default value

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -995,8 +995,8 @@ Data type: `Optional[Variant[Integer[0,7],String[1]]]`
 
       When combined with jump => "LOG" specifies the system log level to log to.
 
-      Note: log level 4/warn is the default setting and as such it is not returned by iptables-save.
-      As a result, explicitly setting `log_level` to this can result in idempotency errors.
+      Note: log level 4/warn is the default setting. iptables-save omits this value, so
+      explicitly setting `log_level` to 4 or "warn" is handled correctly.
 
 ##### `log_prefix`
 

--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -325,7 +325,7 @@ class Puppet::Provider::Firewall::Firewall
     context.debug("Checking whether '#{property_name}' is out of sync")
 
     # If either value is nil, no custom logic is required unless property is source or destination
-    return nil if (is_hash[property_name].nil? || should_hash[property_name].nil?) && ![:source, :destination].include?(property_name) # rubocop:disable Style/ReturnNilInPredicateMethodDefinition -- nil signals "use default comparison" in Puppet's Resource API insync? protocol
+    return nil if (is_hash[property_name].nil? || should_hash[property_name].nil?) && ![:source, :destination, :log_level].include?(property_name) # rubocop:disable Style/ReturnNilInPredicateMethodDefinition -- nil signals "use default comparison" in Puppet's Resource API insync? protocol
 
     case property_name
     when :protocol
@@ -396,9 +396,10 @@ class Puppet::Provider::Firewall::Firewall
       should = PuppetX::Firewall::Utility.icmp_name_to_number(should_hash[property_name], should_hash[:protocol])
       is == should
     when :log_level
-      # Ensure that the values are compared to each other as log level numbers
-      is = PuppetX::Firewall::Utility.log_level_name_to_number(is_hash[property_name])
-      should = PuppetX::Firewall::Utility.log_level_name_to_number(should_hash[property_name])
+      # iptables-save omits --log-level when the kernel default (4/warn) is in use,
+      # so a nil "is" value is equivalent to 4.
+      is = PuppetX::Firewall::Utility.log_level_name_to_number(is_hash[property_name] || '4')
+      should = PuppetX::Firewall::Utility.log_level_name_to_number(should_hash[property_name] || '4')
       is == should
     when :set_mark, :match_mark, :connmark
       # Ensure that the values are compared to eachother in hexidecimal format

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -1230,8 +1230,7 @@ Puppet::ResourceApi.register_type(
       desc: <<-DESC
       When combined with jump => "LOG" specifies the system log level to log to.
 
-      Note: log level 4/warn is the default setting and as such it is not returned by iptables-save.
-      As a result, explicitly setting `log_level` to this can result in idempotency errors.
+      Note: log level 4/warn is the default setting.
       DESC
     },
     log_uid: {

--- a/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
+++ b/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
@@ -173,6 +173,10 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
           { is_hash: { log_level: '1' }, should_hash: { log_level: 'alert' }, result: true },
           { is_hash: { log_level: '1' }, should_hash: { log_level: 1 }, result: true },
           { is_hash: { log_level: '1' }, should_hash: { log_level: 'err' }, result: false },
+          { is_hash: { log_level: nil }, should_hash: { log_level: 4 }, result: true },
+          { is_hash: { log_level: nil }, should_hash: { log_level: 'warn' }, result: true },
+          { is_hash: { log_level: nil }, should_hash: { log_level: 'warning' }, result: true },
+          { is_hash: { log_level: nil }, should_hash: { log_level: 'alert' }, result: false },
         ] },
         { testing: 'set_mark', property_name: :set_mark, comparisons: [
           { is_hash: { set_mark: '42/42' }, should_hash: { set_mark: '0x2a/0x2a' }, result: true },


### PR DESCRIPTION
## Summary

iptables-save omits --log-level when the kernel default (4/warn) is in use. Treat a nil 'is' value as 4 in the log_level insync? comparison so that explicitly setting log_level to 4, 'warn', or 'warning' does not cause spurious changes on every Puppet run.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)