### PR TITLE
(bugfix) Fix ipset idempotency: single-element array not in sync with String equivalent

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -450,6 +450,12 @@ class Puppet::Provider::Firewall::Firewall
       should = should_hash[property_name].to_s.gsub(%r{\s+}, '')
 
       is == should
+    when :ipset
+      is = is_hash[property_name]
+      is = [is] if is.is_a?(String)
+      should = should_hash[property_name]
+      should = [should] if should.is_a?(String)
+      is.sort == should.sort
     else
       # Ensure that if both values are arrays, that they are sorted prior to comparison
       return nil unless is_hash[property_name].is_a?(Array) && should_hash[property_name].is_a?(Array) # rubocop:disable Style/ReturnNilInPredicateMethodDefinition -- nil signals "use default comparison" in Puppet's Resource API insync? protocol

--- a/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
+++ b/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
@@ -216,6 +216,15 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
           { is_hash: { string_hex: '|f46d0425b202000a|' }, should_hash: { string_hex: '|f4 6d 04 25 b2 02 00 0a|' }, result: true },
           { is_hash: { string_hex: '|f4 6d 04 25 b2 02 00 0a|' }, should_hash: { string_hex: '|f4 6d 04 25 b2 02 00 0a|' }, result: true },
         ] },
+        { testing: 'ipset', property_name: :ipset, comparisons: [
+          { is_hash: { ipset: 'setname src' }, should_hash: { ipset: ['setname src'] }, result: true },
+          { is_hash: { ipset: ['setname src'] }, should_hash: { ipset: 'setname src' }, result: true },
+          { is_hash: { ipset: 'setname src' }, should_hash: { ipset: 'setname src' }, result: true },
+          { is_hash: { ipset: ['setname src'] }, should_hash: { ipset: ['setname src'] }, result: true },
+          { is_hash: { ipset: ['setname2 dst', 'setname1 src'] }, should_hash: { ipset: ['setname1 src', 'setname2 dst'] }, result: true },
+          { is_hash: { ipset: 'setname src' }, should_hash: { ipset: 'setname2 dst' }, result: false },
+          { is_hash: { ipset: ['setname src'] }, should_hash: { ipset: ['setname2 dst'] }, result: false },
+        ] },
         # if both values are arrays
         { testing: 'when comparing arrays', property_name: :week_days, comparisons: [
           { is_hash: { week_days: ['Mon', 'Tue', 'Wed'] }, should_hash: { week_days: ['Tue', 'Mon', 'Wed'] }, result: true },


### PR DESCRIPTION
## Summary

Fixes an idempotency bug where a single-element `ipset` array (e.g. `ipset => ['setname src']`) was never considered in sync with the system state. The provider reads a single matched set back from `iptables-save` as a plain String, but the manifest value is an Array, causing `insync?` to fall through to the default comparison and report perpetual drift. The fix adds a dedicated `:ipset` case that normalises both sides to Array before comparing.

Rebase of https://github.com/puppetlabs/puppetlabs-firewall/pull/1208 with added tests

## Checklist

- [x] 🟢 Spec tests
- [x] 🟢 Acceptance tests
- [x] Manually verified