### PR TITLE
(bugfix) Allow underscores in firewall rule names

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1699,7 +1699,7 @@ The following parameters are available in the `firewall` type.
 
 namevar
 
-Data type: `Pattern[/(^\d+(?:[ \t-]\S+)+$)/]`
+Data type: `Pattern[/(^\d+(?:[ \t_-]\S+)+$)/]`
 _*this data type contains a regex that may not be accurately reflected in generated documentation_
 
       The canonical name of the rule. This name is also used for ordering

--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -133,7 +133,7 @@ Puppet::ResourceApi.register_type(
       DESC
     },
     name: {
-      type: 'Pattern[/(^\d+(?:[ \t-]\S+)+$)/]',
+      type: 'Pattern[/(^\d+(?:[ \t_-]\S+)+$)/]',
       behaviour: :namevar,
       desc: <<-DESC
       The canonical name of the rule. This name is also used for ordering

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -26,8 +26,11 @@ RSpec.describe 'firewall type' do
       invalid: [{ name: '001 test rule', ensure: true }, { name: '001 test rule', ensure: 313 }, { name: '001 test rule', ensure: 'false' }]
     },
     ':name': {
-      valid: [{ name: '001 first' }, { name: '202 second rule' }, { name: '333 third rule also' }],
-      invalid: [{ name: 'invalid rule 001' }, { name: 'invalid rule two' }]
+      valid: [{ name: '001 first' }, { name: '202 second rule' }, { name: '333 third rule also' },
+              { name: '001 accept_loopback' }, { name: '100 drop_invalid_packets' },
+              { name: '010 allow-ssh' }, { name: '500 mixed_and-hyphenated rule' }],
+      invalid: [{ name: 'invalid rule 001' }, { name: 'invalid rule two' },
+                { name: '001' }, { name: '001!' }]
     },
     ':protocol': {
       valid: [{ name: '001 test rule', protocol: 'iptables' }, { name: '001 test rule', protocol: 'ip6tables' },


### PR DESCRIPTION
## Summary

The name pattern regex used `[ \t-]` (space, tab, hyphen). Adding `_` as `[ \t-_]` would create an unintended character range from tab (0x09) to underscore (0x5F), accepting most ASCII characters. Fix places `_` before `-` so the hyphen remains a literal: `[ \t_-]`.

Underscores are valid in iptables comments and in wide use, so this extends the allowed separator set without broadening validation further.

Rebase of https://github.com/puppetlabs/puppetlabs-firewall/pull/1174

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)