### PR TITLE
(bugfix) Fix icmp_name_to_number to support type/code format (e.g. 3/4)

### DIFF
--- a/lib/puppet_x/puppetlabs/firewall/utility.rb
+++ b/lib/puppet_x/puppetlabs/firewall/utility.rb
@@ -145,7 +145,7 @@ module PuppetX::Firewall # rubocop:disable Style/ClassAndModuleChildren
 
     # Translate the symbolic names for icmp packet types to integers
     def self.icmp_name_to_number(value_icmp, protocol)
-      if value_icmp.to_s.match?(%r{^\d+$})
+      if value_icmp.to_s.match?(%r{^(\d+|\d+\/\d+)$})
         value_icmp.to_s
       elsif ['IPv4', 'iptables'].include?(protocol)
         # https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml

--- a/lib/puppet_x/puppetlabs/firewall/utility.rb
+++ b/lib/puppet_x/puppetlabs/firewall/utility.rb
@@ -145,7 +145,7 @@ module PuppetX::Firewall # rubocop:disable Style/ClassAndModuleChildren
 
     # Translate the symbolic names for icmp packet types to integers
     def self.icmp_name_to_number(value_icmp, protocol)
-      if value_icmp.to_s.match?(%r{^(\d+|\d+\/\d+)$})
+      if value_icmp.to_s.match?(%r{^\d+(\/\d+)?$})
         value_icmp.to_s
       elsif ['IPv4', 'iptables'].include?(protocol)
         # https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml

--- a/spec/acceptance/rules_spec.rb
+++ b/spec/acceptance/rules_spec.rb
@@ -194,6 +194,12 @@ describe 'rules spec' do
           icmp   => 'time-exceeded',
           jump   => 'ACCEPT',
         }
+        firewall { '014 icmp destination-unreachable/fragmentation-needed':
+          proto  => 'icmp',
+          icmp   => '3/4',
+          jump   => 'ACCEPT',
+        }
+
         firewall { '443 ssl on aliased interface':
           proto   => 'tcp',
           dport   => '443',
@@ -260,6 +266,7 @@ describe 'rules spec' do
       %r{-A INPUT -p (icmp|1) -m icmp --icmp-type 3 -m comment --comment "013 icmp destination-unreachable" -j ACCEPT},
       %r{-A INPUT -s 10.0.0.0/(8|255\.0\.0\.0) -p (icmp|1) -m icmp --icmp-type 8 -m comment --comment "013 icmp echo-request" -j ACCEPT},
       %r{-A INPUT -p (icmp|1) -m icmp --icmp-type 11 -m comment --comment "013 icmp time-exceeded" -j ACCEPT},
+      %r{-A INPUT -p (icmp|1) -m icmp --icmp-type 3/4 -m comment --comment "014 icmp destination-unreachable/fragmentation-needed" -j ACCEPT},
       %r{-A INPUT -p (tcp|6) -m tcp --dport 22 -m conntrack --ctstate NEW -m comment --comment "020 ssh" -j ACCEPT},
       %r{-A INPUT -i eth0:3 -p (tcp|6) -m tcp --dport 443 -m conntrack --ctstate NEW -m comment --comment "443 ssl on aliased interface" -j ACCEPT},
       %r{-A INPUT -m comment --comment "900 LOCAL_INPUT" -j LOCAL_INPUT},

--- a/spec/unit/puppet_x/puppetlabs/firewall/utility_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/firewall/utility_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe PuppetX::Firewall::Utility do
       it { expect(utility.icmp_name_to_number('timestamp-reply', proto)).to eql '14' }
       it { expect(utility.icmp_name_to_number('address-mask-request', proto)).to eql '17' }
       it { expect(utility.icmp_name_to_number('address-mask-reply', proto)).to eql '18' }
-      it { expect(utility.icmp_name_to_number('3/4', proto)).to eql '3/4' }
+      it { expect(utility.icmp_name_to_number('3/40', proto)).to eql '3/40' }
     end
 
     context 'with proto IPv6' do

--- a/spec/unit/puppet_x/puppetlabs/firewall/utility_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/firewall/utility_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe PuppetX::Firewall::Utility do
       it { expect(utility.icmp_name_to_number('timestamp-reply', proto)).to eql '14' }
       it { expect(utility.icmp_name_to_number('address-mask-request', proto)).to eql '17' }
       it { expect(utility.icmp_name_to_number('address-mask-reply', proto)).to eql '18' }
+      it { expect(utility.icmp_name_to_number('3/4', proto)).to eql '3/4' }
     end
 
     context 'with proto IPv6' do


### PR DESCRIPTION
## Summary

The `icmp_name_to_number` helper in `utility.rb` was broken during the v7 Resource API refactor — the updated regex no longer accepted ICMP strings in `<type>/<code>` format (e.g. `3/4`), causing the method to return `nil` instead of passing the value through. This prevented users from writing rules that match on both ICMP type and code, such as `icmptype 3 code 4` (fragmentation needed). This PR restores that behaviour by correcting the regex to `^\d+(\/\d+)?$`, and updates the accompanying spec to verify that multi-digit code values are also handled correctly.

This is a rebase of https://github.com/puppetlabs/puppetlabs-firewall/pull/1234

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)