### PR TITLE
(#1266) Strip iptables-legacy warnings interleaved in iptables-save output

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -482,6 +482,9 @@ class Puppet::Provider::Firewall::Firewall
     protocols.each do |protocol|
       # Retrieve String containing all information
       iptables_list = Puppet::Provider.execute($fw_list_command[protocol], combine: false, failonfail: true)
+      # Strip any iptables warning messages that may be interleaved mid-line in the output
+      # (e.g. "# Warning: iptables-legacy tables present"), which can corrupt rule parsing.
+      iptables_list = iptables_list.gsub(%r{# Warning:[^\n]*\n?}, '')
       # Scan String to retrieve all Rules
       iptables_list.scan($fw_table_regex).each do |table|
         table_name = table[0].scan($fw_table_name_regex)[0][0]

--- a/spec/unit/puppet/provider/firewall/firewall_private_get_spec.rb
+++ b/spec/unit/puppet/provider/firewall/firewall_private_get_spec.rb
@@ -81,6 +81,34 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
           expect(names).to include('001 allow * tcp', '002 test rule', '003 raw rule')
         end
       end
+
+      context 'when a legacy iptables warning is interleaved mid-line in the output (issue #1266)' do
+        let(:iptables_output) do
+          # Simulates the bug where an iptables-legacy warning is injected mid-line
+          # inside a --comment value, splitting the rule across two lines. This happens
+          # when the warning is not fully separated from stdout before being read.
+          <<~IPTABLES
+            *filter
+            :INPUT ACCEPT [0:0]
+            :FORWARD ACCEPT [0:0]
+            :OUTPUT ACCEPT [0:0]
+            -A FORWARD ! -s 10.42.0.0/16 -d 10.43.161.110/32 -p tcp -m comment --comment "001 allow forward# Warning: iptables-legacy tables present, use iptables-legacy save to see them
+            " -j ACCEPT
+            -A INPUT -p tcp -m comment --comment "002 allow ssh" -j ACCEPT
+            COMMIT
+          IPTABLES
+        end
+
+        it 'correctly parses all rules after stripping the interleaved warning' do
+          allow(Puppet::Provider).to receive(:execute).with('iptables-save', any_args).and_return(iptables_output)
+          allow(Puppet::Provider).to receive(:execute).with('ip6tables-save', any_args).and_return('')
+
+          rules = provider.get_rules(context, true, ['IPv4'])
+          names = rules.map { |r| r[:name] }
+
+          expect(names).to include('001 allow forward', '002 allow ssh')
+        end
+      end
     end
 
     describe 'self.rule_to_hash(_context, rule, table_name, protocol)' do


### PR DESCRIPTION
## Summary

Fixes #1266.

On systems where `iptables-save` emits legacy compatibility warnings (e.g. k3s-managed hosts with both iptables-legacy and nftables-backed rules), the warning text can be interleaved mid-line into the stdout output. This injects text like:

```
# Warning: iptables-legacy tables present, use iptables-legacy save to see them
```

directly inside a rule's `--comment` value, splitting the line and leaving the opening `"` unclosed. The rule name regex then fails to match, and rule parsing either silently drops the name or crashes with `NoMethodError: undefined method '[]' for nil:NilClass`.

The fix strips any `# Warning:` lines from the raw `iptables-save` output before scanning. When a warning is injected mid-line, removing it (along with its trailing newline) rejoins the two fragments back into a valid rule line. When it appears on its own line it is harmless to remove since such lines are already skipped by the rules regex.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)