### PR TITLE
(#1257) Allow dots in ipset names for the ipset attribute pattern

### DIFF
--- a/lib/puppet/type/firewall.rb
+++ b/lib/puppet/type/firewall.rb
@@ -966,7 +966,7 @@ Puppet::ResourceApi.register_type(
       DESC
     },
     ipset: {
-      type: 'Optional[Variant[Pattern[/^(?:!\s)?[\w\-:_]+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?[\w\-:_]+\s(?:src|dst)(?:,src|,dst)?$/]]]]',
+      type: 'Optional[Variant[Pattern[/^(?:!\s)?[\w\-:_.]+\s(?:src|dst)(?:,src|,dst)?$/], Array[Pattern[/^(?:!\s)?[\w\-:_.]+\s(?:src|dst)(?:,src|,dst)?$/]]]]',
       desc: <<-DESC
       Matches against the specified ipset list.
       Requires ipset kernel module. Will accept a single element or an array.

--- a/spec/unit/puppet/type/firewall_spec.rb
+++ b/spec/unit/puppet/type/firewall_spec.rb
@@ -372,7 +372,8 @@ RSpec.describe 'firewall type' do
     },
     ':ipset': {
       valid: [{ name: '001 test rule', ipset: 'setname1 src' }, { name: '001 test rule', ipset: '! setname2 dst' },
-              { name: '001 test rule', ipset: ['setname1 src', '! setname2 dst'] }],
+              { name: '001 test rule', ipset: ['setname1 src', '! setname2 dst'] },
+              { name: '001 test rule', ipset: 'i360.ipv4.no-redirect-port dst' }],
       invalid: [{ name: '001 test rule', ipset: 'invalid' }, { name: '001 test rule', ipset: false },
                 { name: '001 test rule', ipset: false }]
     },


### PR DESCRIPTION
Fix for https://github.com/puppetlabs/puppetlabs-firewall/issues/1257

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)