### PR TITLE
(#1254) Remove iptables-services from EL9+ package defaults

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class firewall::params {
           if versioncmp($facts['os']['release']['full'], '9') >= 0 {
             $service_name = ['nftables','iptables']
             $service_name_v6 = 'ip6tables'
-            $package_name = ['iptables-services', 'nftables', 'iptables-nft-services']
+            $package_name = ['iptables-nft-services', 'nftables']
             $iptables_name = 'iptables-nft'
             $sysconfig_manage = false
             $firewalld_manage = true

--- a/spec/unit/classes/firewall_linux_redhat_spec.rb
+++ b/spec/unit/classes/firewall_linux_redhat_spec.rb
@@ -37,6 +37,7 @@ describe 'firewall::linux::redhat', type: :class do
   ['RedHat', 'CentOS', 'Fedora', 'AlmaLinux'].each do |os|
     releases = ((os == 'Fedora') ? ['36'] : ['7.0.1406'])
     nftablesreleases = ((os == 'Fedora') ? [] : ['8.0'])
+    el9releases = ((os == 'Fedora') ? [] : ['9.0'])
 
     releases.each do |osrel|
       context "with os #{os} and osrel #{osrel}" do
@@ -203,6 +204,90 @@ describe 'firewall::linux::redhat', type: :class do
             ensure: 'installed',
             before: ['Service[iptables]', 'Service[nftables]'],
           )
+        }
+
+        it {
+          expect(subject).not_to contain_file('/etc/sysconfig/nftables')
+        }
+      end
+    end
+
+    el9releases.each do |osrel|
+      context "with os #{os} and osrel #{osrel}" do
+        let(:facts) do
+          {
+            kernel: 'Linux',
+            os: {
+              name: os,
+              release: { full: osrel },
+              family: 'RedHat',
+              selinux: { enabled: false }
+            },
+            puppetversion: Puppet.version
+          }
+        end
+
+        it {
+          expect(subject).to contain_service('nftables').with(
+            ensure: 'running',
+            enable: 'true',
+          )
+          expect(subject).to contain_service('iptables').with(
+            ensure: 'running',
+            enable: 'true',
+          )
+        }
+
+        context 'with ensure => stopped' do
+          let(:params) { { ensure: 'stopped' } }
+
+          it {
+            expect(subject).to contain_service('nftables').with(
+              ensure: 'stopped',
+            )
+            expect(subject).to contain_service('iptables').with(
+              ensure: 'stopped',
+            )
+          }
+        end
+
+        context 'with enable => false' do
+          let(:params) { { enable: 'false' } }
+
+          it {
+            expect(subject).to contain_service('nftables').with(
+              enable: 'false',
+            )
+            expect(subject).to contain_service('iptables').with(
+              enable: 'false',
+            )
+          }
+        end
+
+        it {
+          expect(subject).to contain_service('firewalld').with(
+            ensure: 'stopped',
+            enable: false,
+            before: ['Package[iptables-nft-services]', 'Package[nftables]', 'Service[nftables]', 'Service[iptables]'],
+          )
+        }
+
+        it {
+          expect(subject).to contain_package('iptables-nft-services').with(
+            ensure: 'installed',
+            before: ['Service[nftables]', 'Service[iptables]'],
+          )
+        }
+
+        it {
+          expect(subject).to contain_package('nftables').with(
+            ensure: 'installed',
+            before: ['Service[nftables]', 'Service[iptables]'],
+          )
+        }
+
+        it {
+          expect(subject).not_to contain_package('iptables-services')
         }
 
         it {


### PR DESCRIPTION
## Summary

- Removes `iptables-services` from the default package list for EL9+ systems (RHEL, CentOS, AlmaLinux)
- Replaces it with `iptables-nft-services`, which is shipped by the distribution and provides the same functionality
- EL8 and earlier are unaffected; their `iptables-services` default is preserved

## Additional Context

On EL9+, `iptables` is implemented via nftables under the hood. The `iptables-services` package from EPEL belongs to the `iptables-legacy-*` stack and conflicts with `iptables-libs` updates, causing broken package state on systems that pull it in — even when Puppet wasn't responsible for installing it ([RHEL Bug 2343682](https://bugzilla.redhat.com/show_bug.cgi?id=2343682)).

`iptables-nft-services` is the correct EL9 equivalent: it is part of the official distribution and provides the service units needed by this module.

## Related Issues

Fixes #1254

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)