### PR TITLE
Add PDK Update workflow

### DIFF
--- a/.github/workflows/pdk_update.yml
+++ b/.github/workflows/pdk_update.yml
@@ -1,0 +1,18 @@
+name: "PDK Update"
+
+on:
+  # Run weekly to keep the module template up to date...
+  schedule:
+    - cron: "0 4 * * 1"  # Mondays at 04:00 UTC
+  # ...and allow manual runs.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pdk_update:
+    # NOTE: pinned to the unmerged branch for testing; switch to @main once merged.
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_pdk_update.yml@pdk_update_workflow"
+    secrets: "inherit"


### PR DESCRIPTION
## Summary

Call the module_pdk_update reusable workflow to run `pdk update` weekly (and on demand) and open/refresh a pdk_update PR. Pinned to the unmerged cat-github-actions branch for testing.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)