### PR TITLE
(CAT-2682) Update .sync.yml with new night.yml/ci.yml flags

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -28,9 +28,23 @@ spec/spec_helper.rb:
 .github/workflows/auto_release.yml:
   unmanaged: false
 .github/workflows/ci.yml:
-  unmanaged: true
+  unmanaged: false
+  acceptance_flags:
+    - '--nightly'
+    - '--platform-exclude centos-7'
+    - '--platform-exclude oraclelinux-7'
+    - '--platform-exclude scientific-7'
+    - '--platform-exclude centos-8'
+    - '--platform-exclude rocky-8'
 .github/workflows/nightly.yml:
-  unmanaged: true
+  unmanaged: false
+  acceptance_flags:
+    - '--nightly'
+    - '--platform-exclude centos-7'
+    - '--platform-exclude oraclelinux-7'
+    - '--platform-exclude scientific-7'
+    - '--platform-exclude centos-8'
+    - '--platform-exclude rocky-8'
 .github/workflows/release.yml:
   unmanaged: false
 .travis.yml:


### PR DESCRIPTION
## Summary

Update unmanaged status to false for CI and nightly workflows and  added acceptance flags for platform exclusions.

## Related ticket / issue

- Ticket / issue: [CAT-2682](https://perforce.atlassian.net/browse/CAT-2682)

## Required checklist

- [ ] Linked the driving ticket or issue above where one exists (a `MODULES-*` ticket via the structured spec template, or a GitHub issue).
- [ ] Coverage gate is green (or the baseline is preserved -- coverage was not reduced).
- [ ] Platform matrix is green -- the PR's CI checks below cover it, or link a recent nightly Litmus run if the supported-OS acceptance tests do not run on this PR.
- [ ] `Co-Authored-By: Claude` trailer is present on the commits if this PR was AI-assisted.

This PR is (check one):

- [ ] Auto-merge
- [ ] Single reviewer
- [ ] Full review (2+)
