### PR TITLE
(#1214) Cache iptables-save reads for the duration of a catalog run

### DIFF
--- a/lib/puppet/provider/firewall/firewall.rb
+++ b/lib/puppet/provider/firewall/firewall.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../puppet_x/puppetlabs/firewall/utility'
+require_relative '../../../puppet_x/puppetlabs/firewall/cache'
 
 # Implementation for the iptables type using the Resource API.
 class Puppet::Provider::Firewall::Firewall
@@ -302,6 +303,7 @@ class Puppet::Provider::Firewall::Firewall
     position = Puppet::Provider::Firewall::Firewall.insert_order(context, name, should[:chain], should[:table], should[:protocol])
     arguments = Puppet::Provider::Firewall::Firewall.hash_to_rule(context, name, should)
     Puppet::Provider.execute([$fw_base_command[should[:protocol]], should[:table], $fw_rule_create_command, should[:chain], position, arguments].join(' '))
+    PuppetX::Firewall::Cache.invalidate
     PuppetX::Firewall::Utility.persist_iptables(context, name, should[:protocol])
   end
 
@@ -310,6 +312,7 @@ class Puppet::Provider::Firewall::Firewall
     position = Puppet::Provider::Firewall::Firewall.insert_order(context, name, should[:chain], should[:table], should[:protocol])
     arguments = Puppet::Provider::Firewall::Firewall.hash_to_rule(context, name, should)
     Puppet::Provider.execute([$fw_base_command[should[:protocol]], should[:table], $fw_rule_update_command, should[:chain], position, arguments].join(' '))
+    PuppetX::Firewall::Cache.invalidate
     PuppetX::Firewall::Utility.persist_iptables(context, name, should[:protocol])
   end
 
@@ -319,6 +322,7 @@ class Puppet::Provider::Firewall::Firewall
     # We do this to ensure accuracy when removing non-standard (i.e. uncommented) rules via the firewallchain purge function
     arguments = is[:line].gsub(%r{^-A}, $fw_rule_delete_command)
     Puppet::Provider.execute([$fw_base_command[is[:protocol]], is[:table], arguments].join(' '))
+    PuppetX::Firewall::Cache.invalidate
     PuppetX::Firewall::Utility.persist_iptables(context, name, is[:protocol])
   end
 
@@ -475,13 +479,31 @@ class Puppet::Provider::Firewall::Firewall
   #   while also allowing for the protocols used to retrieve the rules to be limited.
   # @api private
   def self.get_rules(context, basic, protocols = ['IPv4', 'IPv6'])
+    # The Resource API calls `get` once per firewall resource in the catalog,
+    # and each create/update triggers a further read via `insert_order`. All of
+    # those reads happen within a single catalog application, so the parsed
+    # ruleset is cached for the duration of the run and dropped whenever this
+    # module changes a rule or chain.
+    rules = PuppetX::Firewall::Cache.fetch([:parsed_rules, basic, protocols]) do
+      parse_rules(context, basic, protocols)
+    end
+    # Return copies (including copies of array values, which insync? compares
+    # and future code may sort or negate in place) so that callers cannot
+    # alter the cached entries. This matches the previous behaviour, where
+    # every call produced freshly parsed hashes.
+    rules.map { |rule| rule.transform_values { |value| value.is_a?(Array) ? value.dup : value } }
+  end
+
+  # Retrieve and parse the current ruleset for the given protocols
+  # @api private
+  def self.parse_rules(context, basic, protocols)
     # Create empty return array
     rules = []
     counter = 1
     # For each protocol
     protocols.each do |protocol|
       # Retrieve String containing all information
-      iptables_list = Puppet::Provider.execute($fw_list_command[protocol], combine: false, failonfail: true)
+      iptables_list = save_output(protocol)
       # Strip any iptables warning messages that may be interleaved mid-line in the output
       # (e.g. "# Warning: iptables-legacy tables present"), which can corrupt rule parsing.
       iptables_list = iptables_list.gsub(%r{# Warning:[^\n]*\n?}, '')
@@ -491,20 +513,28 @@ class Puppet::Provider::Firewall::Firewall
         table[0].scan($fw_rules_regex).each do |rule|
           # iptables-save escapes ' symbol in it's output for some reason which leads to an incorrect command
           # We need to manually replace \' to '
-          rule[0].gsub!("\\'", "'")
+          line = rule[0].gsub("\\'", "'")
           raw_rules = if basic
-                        Puppet::Provider::Firewall::Firewall.rule_to_name(context, rule[0], table_name, protocol)
+                        Puppet::Provider::Firewall::Firewall.rule_to_name(context, line, table_name, protocol)
                       else
-                        Puppet::Provider::Firewall::Firewall.rule_to_hash(context, rule[0], table_name, protocol)
+                        Puppet::Provider::Firewall::Firewall.rule_to_hash(context, line, table_name, protocol)
                       end
           # Process the returned values so that it is correct for our purposes
-          rules << Puppet::Provider::Firewall::Firewall.process_get(context, raw_rules, rule[0], counter)
+          rules << Puppet::Provider::Firewall::Firewall.process_get(context, raw_rules, line, counter)
           counter += 1
         end
       end
       # Return array
     end
     rules
+  end
+
+  # Retrieve the raw `iptables-save` output for the given protocol
+  # @api private
+  def self.save_output(protocol)
+    PuppetX::Firewall::Cache.fetch($fw_list_command[protocol]) do
+      Puppet::Provider.execute($fw_list_command[protocol], combine: false, failonfail: true)
+    end
   end
 
   # Simplified version of 'self.rules_to_hash' meant to return name, chain and table only

--- a/lib/puppet/provider/firewallchain/firewallchain.rb
+++ b/lib/puppet/provider/firewallchain/firewallchain.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../puppet_x/puppetlabs/firewall/utility'
+require_relative '../../../puppet_x/puppetlabs/firewall/cache'
 
 # Implementation for the firewallchain type using the Resource API.
 class Puppet::Provider::Firewallchain::Firewallchain
@@ -51,7 +52,13 @@ class Puppet::Provider::Firewallchain::Firewallchain
     ['IPv4', 'IPv6'].each do |protocol|
       # Go through each supported table and retrieve its chains if it exists.
       $fwc_supported_tables.each do |table_name|
-        cmd_output = Puppet::Provider.execute([$fwc_list_command[protocol], '-t', table_name].join(' '), failonfail: false)
+        # The Resource API calls `get` once per firewallchain resource in the
+        # catalog, so the command output is cached for the duration of the run
+        # and dropped whenever this module changes a rule or chain.
+        command = [$fwc_list_command[protocol], '-t', table_name].join(' ')
+        cmd_output = PuppetX::Firewall::Cache.fetch(command) do
+          Puppet::Provider.execute(command, failonfail: false)
+        end
         cmd_output.scan($fwc_chain_regex).each do |chain|
           # Create the base hash
           chain_hash = {
@@ -106,6 +113,7 @@ class Puppet::Provider::Firewallchain::Firewallchain
     else
       Puppet::Provider.execute([$fwc_base_command[should[:protocol]], should[:table], $fwc_chain_create_command, should[:chain]].join(' '))
     end
+    PuppetX::Firewall::Cache.invalidate
     PuppetX::Firewall::Utility.persist_iptables(context, name, should[:protocol])
   end
 
@@ -116,6 +124,7 @@ class Puppet::Provider::Firewallchain::Firewallchain
 
     context.notice("Updating Chain '#{name}' with #{should.inspect}")
     Puppet::Provider.execute([$fwc_base_command[should[:protocol]], should[:table], $fwc_chain_policy_command, should[:chain], should[:policy].upcase].join(' '))
+    PuppetX::Firewall::Cache.invalidate
     PuppetX::Firewall::Utility.persist_iptables(context, name, should[:protocol])
   end
 
@@ -132,6 +141,7 @@ class Puppet::Provider::Firewallchain::Firewallchain
       context.notice("Deleting Chain '#{name}'")
       Puppet::Provider.execute([$fwc_base_command[is[:protocol]], is[:table], $fwc_chain_delete_command, is[:chain]].join(' '))
     end
+    PuppetX::Firewall::Cache.invalidate
     PuppetX::Firewall::Utility.persist_iptables(context, name, is[:protocol])
   end
 

--- a/lib/puppet_x/puppetlabs/firewall/cache.rb
+++ b/lib/puppet_x/puppetlabs/firewall/cache.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'puppet_x'
+
+module PuppetX::Firewall # rubocop:disable Style/ClassAndModuleChildren
+  # A read cache for `iptables-save` style command output and its parsed form,
+  # scoped to a single catalog application.
+  #
+  # The Resource API calls a provider's `get` method once for every resource of
+  # that type in the catalog. Without caching that means one full
+  # `iptables-save`/`ip6tables-save` execution and a full parse of the entire
+  # ruleset per managed rule, per run. All of those reads happen within a single
+  # catalog application against a ruleset that only this module is changing, so
+  # they can safely share one snapshot.
+  #
+  # Scoping and invalidation:
+  # - Entries are keyed to the object identity of Puppet's :current_environment
+  #   context binding. The agent binds a fresh environment object for every
+  #   catalog run, so a new run never observes a previous run's snapshot.
+  # - Any provider action that changes rules or chains must call `invalidate`,
+  #   which drops the whole cache so the next read re-executes the underlying
+  #   command and observes the change.
+  # - When no :current_environment binding is available caching is disabled and
+  #   every read executes the underlying command, matching previous behaviour.
+  class Cache
+    class << self
+      # Fetch the cached value for `key`, computing and caching the result of
+      # the given block on a miss. Computes without caching when no run context
+      # is available.
+      def fetch(key)
+        token = run_token
+        return yield if token.nil?
+
+        unless token.equal?(@run_token)
+          @store = {}
+          @run_token = token
+        end
+
+        @store.fetch(key) { @store[key] = yield }
+      end
+
+      # Drop all cached data. Must be called after any operation that modifies
+      # rules or chains.
+      def invalidate
+        @store = {}
+      end
+
+      private
+
+      # An object identifying the current catalog application. The agent and
+      # apply applications bind a fresh Puppet::Node::Environment for every
+      # run and pop it when the run finishes.
+      def run_token
+        Puppet.lookup(:current_environment) { nil }
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -29,6 +29,17 @@ if ENV['COVERAGE'] == 'yes'
   end
 end
 
+require 'puppet_x/puppetlabs/firewall/cache'
+
+RSpec.configure do |c|
+  # The run-scoped cache is keyed to Puppet's :current_environment binding,
+  # which the spec harness keeps stable across examples. Real agent runs bind a
+  # fresh environment per run; in specs we drop the cache before each example.
+  c.before(:each) do
+    PuppetX::Firewall::Cache.invalidate
+  end
+end
+
 shared_context 'when ArchLinux' do
   let :facts do
     {

--- a/spec/unit/puppet/provider/firewall/firewall_private_get_spec.rb
+++ b/spec/unit/puppet/provider/firewall/firewall_private_get_spec.rb
@@ -109,6 +109,62 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
           expect(names).to include('001 allow forward', '002 allow ssh')
         end
       end
+
+      context 'when called multiple times within a single run (issue #1214)' do
+        let(:iptables_output) do
+          <<~IPTABLES
+            *filter
+            :INPUT ACCEPT [0:0]
+            -A INPUT -p tcp -m comment --comment "001 allow ssh" -j ACCEPT
+            -A INPUT -p tcp -m comment --comment "002 allow https" -j ACCEPT
+            COMMIT
+          IPTABLES
+        end
+
+        before(:each) do
+          allow(Puppet).to receive(:lookup).and_call_original
+          allow(Puppet).to receive(:lookup).with(:current_environment).and_return(instance_double(Puppet::Node::Environment))
+          allow(Puppet::Provider).to receive(:execute).with('iptables-save', any_args).and_return(iptables_output)
+          allow(Puppet::Provider).to receive(:execute).with('ip6tables-save', any_args).and_return('')
+        end
+
+        it 'executes iptables-save only once per protocol' do
+          expect(Puppet::Provider).to receive(:execute).with('iptables-save', any_args).once.and_return(iptables_output)
+          expect(Puppet::Provider).to receive(:execute).with('ip6tables-save', any_args).once.and_return('')
+
+          2.times { provider.get_rules(context, false) }
+        end
+
+        it 'returns the same rules on every call' do
+          first = provider.get_rules(context, false)
+          second = provider.get_rules(context, false)
+
+          expect(second).to eq(first)
+        end
+
+        it 'reuses the same snapshot for basic reads' do
+          expect(Puppet::Provider).to receive(:execute).with('iptables-save', any_args).once.and_return(iptables_output)
+
+          provider.get_rules(context, false)
+          rules = provider.get_rules(context, true, ['IPv4'])
+
+          expect(rules.map { |r| r[:name] }).to eq(['001 allow ssh', '002 allow https'])
+        end
+
+        it 'does not let callers alter the cached rules' do
+          provider.get_rules(context, false)[0][:name] = 'altered'
+
+          expect(provider.get_rules(context, false)[0][:name]).to eq('001 allow ssh')
+        end
+
+        it 'executes iptables-save again after the cache is invalidated' do
+          expect(Puppet::Provider).to receive(:execute).with('iptables-save', any_args).twice.and_return(iptables_output)
+
+          provider.get_rules(context, false)
+          PuppetX::Firewall::Cache.invalidate
+          provider.get_rules(context, false)
+        end
+      end
     end
 
     describe 'self.rule_to_hash(_context, rule, table_name, protocol)' do

--- a/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
+++ b/spec/unit/puppet/provider/firewall/firewall_public_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
           provider.create(context, test[:should][:name], test[:should])
         end
       end
+
+      it 'invalidates the run cache' do
+        should = { name: '001 IPv4 Test Rule', chain: 'INPUT', table: 'filter', protocol: 'IPv4', ensure: 'present' }
+        allow(context).to receive(:notice)
+        allow(described_class).to receive_messages(insert_order: 1, hash_to_rule: '-m comment --comment "001 Test Rule"')
+        allow(Puppet::Util::Execution).to receive(:execute)
+        allow(PuppetX::Firewall::Utility).to receive(:persist_iptables)
+        expect(PuppetX::Firewall::Cache).to receive(:invalidate)
+
+        provider.create(context, should[:name], should)
+      end
     end
 
     describe 'update(context, name, should, is)' do
@@ -72,6 +83,17 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
 
           provider.update(context, test[:should][:name], test[:should])
         end
+      end
+
+      it 'invalidates the run cache' do
+        should = { name: '001 IPv4 Test Rule', chain: 'INPUT', table: 'filter', protocol: 'IPv4', ensure: 'present' }
+        allow(context).to receive(:notice)
+        allow(described_class).to receive_messages(insert_order: 1, hash_to_rule: '-m comment --comment "001 Test Rule"')
+        allow(Puppet::Util::Execution).to receive(:execute)
+        allow(PuppetX::Firewall::Utility).to receive(:persist_iptables)
+        expect(PuppetX::Firewall::Cache).to receive(:invalidate)
+
+        provider.update(context, should[:name], should)
       end
     end
 
@@ -101,6 +123,19 @@ RSpec.describe Puppet::Provider::Firewall::Firewall do
 
           provider.delete(context, test[:is][:name], test[:is])
         end
+      end
+
+      it 'invalidates the run cache' do
+        is = {
+          name: '001 IPv4 Test Rule', chain: 'INPUT', table: 'filter', protocol: 'IPv4', ensure: 'present',
+          line: '-A INPUT 1 -m comment --comment "001 Test Rule"'
+        }
+        allow(context).to receive(:notice)
+        allow(Puppet::Util::Execution).to receive(:execute)
+        allow(PuppetX::Firewall::Utility).to receive(:persist_iptables)
+        expect(PuppetX::Firewall::Cache).to receive(:invalidate)
+
+        provider.delete(context, is[:name], is)
       end
     end
 

--- a/spec/unit/puppet/provider/firewallchain/firewallchain_spec.rb
+++ b/spec/unit/puppet/provider/firewallchain/firewallchain_spec.rb
@@ -133,6 +133,39 @@ COMMIT
 
         expect(provider.get(context)).to eq(returned_data)
       end
+
+      context 'when called multiple times within a single run (issue #1214)' do
+        before(:each) do
+          allow(Puppet).to receive(:lookup).and_call_original
+          allow(Puppet).to receive(:lookup).with(:current_environment).and_return(instance_double(Puppet::Node::Environment))
+          ['nat', 'mangle', 'filter', 'raw', 'rawpost', 'broute', 'security'].each do |table|
+            allow(Puppet::Provider).to receive(:execute).with("iptables-save -t #{table}", any_args).and_return(iptables)
+            allow(Puppet::Provider).to receive(:execute).with("ip6tables-save -t #{table}", any_args).and_return(ip6tables)
+          end
+        end
+
+        it 'executes each list command only once' do
+          expect(Puppet::Provider).to receive(:execute).with('iptables-save -t filter', any_args).once.and_return(iptables)
+          expect(Puppet::Provider).to receive(:execute).with('ip6tables-save -t filter', any_args).once.and_return(ip6tables)
+
+          2.times { provider.get(context) }
+        end
+
+        it 'returns the same chains on every call' do
+          first = provider.get(context)
+          second = provider.get(context)
+
+          expect(second).to eq(first)
+        end
+
+        it 'executes the list commands again after the cache is invalidated' do
+          expect(Puppet::Provider).to receive(:execute).with('iptables-save -t filter', any_args).twice.and_return(iptables)
+
+          provider.get(context)
+          PuppetX::Firewall::Cache.invalidate
+          provider.get(context)
+        end
+      end
     end
 
     describe 'create(context, name, should)' do
@@ -153,6 +186,16 @@ COMMIT
 
           provider.create(context, test[:should][:name], test[:should])
         end
+      end
+
+      it 'invalidates the run cache' do
+        should = { name: 'TEST_ONE:filter:IPv4', chain: 'TEST_ONE', table: 'filter', protocol: 'IPv4', purge: false, ignore_foreign: false, ensure: 'present' }
+        allow(context).to receive(:notice)
+        allow(Puppet::Util::Execution).to receive(:execute)
+        allow(PuppetX::Firewall::Utility).to receive(:persist_iptables)
+        expect(PuppetX::Firewall::Cache).to receive(:invalidate)
+
+        provider.create(context, should[:name], should)
       end
     end
 
@@ -226,6 +269,16 @@ COMMIT
 
             provider.delete(context, test[:is][:name], test[:is])
           end
+        end
+
+        it 'invalidates the run cache after the chain and its rules are removed' do
+          is = { name: 'TEST_ONE:filter:IPv4', chain: 'TEST_ONE', table: 'filter', protocol: 'IPv4', purge: false, ignore_foreign: false, ensure: 'present', policy: 'accept' }
+          allow(context).to receive(:notice)
+          allow(Puppet::Util::Execution).to receive(:execute)
+          allow(PuppetX::Firewall::Utility).to receive(:persist_iptables)
+          expect(PuppetX::Firewall::Cache).to receive(:invalidate)
+
+          provider.delete(context, is[:name], is)
         end
       end
 

--- a/spec/unit/puppet_x/puppetlabs/firewall/cache_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/firewall/cache_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet_x/puppetlabs/firewall/cache'
+
+RSpec.describe PuppetX::Firewall::Cache do
+  let(:environment) { instance_double(Puppet::Node::Environment) }
+
+  context 'when a run context is available' do
+    before(:each) do
+      allow(Puppet).to receive(:lookup).and_call_original
+      allow(Puppet).to receive(:lookup).with(:current_environment).and_return(environment)
+    end
+
+    it 'computes the value once per key' do
+      calls = 0
+      2.times { described_class.fetch(:key) { calls += 1 } }
+      expect(calls).to eq(1)
+    end
+
+    it 'returns the cached value on subsequent fetches' do
+      described_class.fetch(:key) { 'value' }
+      expect(described_class.fetch(:key) { 'other' }).to eq('value')
+    end
+
+    it 'computes separate values for separate keys' do
+      described_class.fetch(:one) { 'first' }
+      expect(described_class.fetch(:two) { 'second' }).to eq('second')
+    end
+
+    it 'recomputes after invalidate' do
+      described_class.fetch(:key) { 'value' }
+      described_class.invalidate
+      expect(described_class.fetch(:key) { 'other' }).to eq('other')
+    end
+
+    it 'recomputes when the run context changes' do
+      other_environment = instance_double(Puppet::Node::Environment)
+      described_class.fetch(:key) { 'value' }
+      allow(Puppet).to receive(:lookup).with(:current_environment).and_return(other_environment)
+      expect(described_class.fetch(:key) { 'other' }).to eq('other')
+    end
+  end
+
+  context 'when no run context is available' do
+    before(:each) do
+      allow(Puppet).to receive(:lookup).and_call_original
+      allow(Puppet).to receive(:lookup).with(:current_environment).and_return(nil)
+    end
+
+    it 'computes the value every time' do
+      calls = 0
+      2.times { described_class.fetch(:key) { calls += 1 } }
+      expect(calls).to eq(2)
+    end
+  end
+
+  context 'when looking up the run context raises' do
+    before(:each) do
+      allow(Puppet).to receive(:lookup).and_call_original
+      allow(Puppet).to receive(:lookup).with(:current_environment).and_raise(Puppet::Error, 'no context')
+    end
+
+    it 'computes the value every time' do
+      calls = 0
+      2.times { described_class.fetch(:key) { calls += 1 } }
+      expect(calls).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the performance degradation reported in #1214, where catalog application time grew from seconds to many minutes after the Resource API migration.

The Resource API calls a provider's `get` once for every resource of that type in the catalog (`refresh_current_state` performs a full `get`, then `find`s the single resource being evaluated). For this module that means, per catalog run, even when nothing has changed:

- per `firewall` resource: one `iptables-save` + one `ip6tables-save` execution, plus a full regex parse of the entire ruleset (~150 attribute patterns per rule);
- per `firewallchain` resource: one `iptables-save -t <table>` execution for each of the 7 supported tables x 2 protocols.

A catalog with N rules on a host with M total rules therefore does O(N) command executions and O(N x M) parse work. The original report's "~296 iptables-save calls for ~60 rules" and the later reports of hour-long runs on hosts with ~1100 unmanaged rules follow directly from this.

This PR adds `PuppetX::Firewall::Cache`, a read cache for list-command output and its parsed form, shared by both providers and scoped to a single catalog application:

- Entries are keyed to the object identity of Puppet's `:current_environment` context binding. The agent binds a fresh `Puppet::Node::Environment` for every catalog run (`Configurer#push_current_environment_and_loaders`) and pops it when the run finishes, so a new run never observes a previous run's snapshot - external drift is still picked up on every run.
- Any `create`/`update`/`delete` of a rule or chain invalidates the whole cache, so the next read re-executes the underlying command and observes the change (the cache is shared between the two providers precisely so that chain flushes invalidate rule reads).
- When no `:current_environment` binding is available, caching is disabled and every read executes the underlying command, i.e. previous behaviour.

`get_rules` returns per-caller copies of cached entries (the hashes and their array values), so callers cannot alter the snapshot. This restores the read semantics of the legacy (pre-7.x) type/provider, whose `prefetch` also read the ruleset once per transaction.

Results, unchanged catalog, firewall resource evaluation only (synthetic benchmark):

| Scenario | v8.5.0 | this PR |
|---|---|---|
| 100 rules managed, 500 unmanaged | 40.5 s, 200 execs | 0.5 s, 2 execs |
| 100 rules managed, 4000 unmanaged | ~270 s, 200 execs | 3.9 s, 2 execs |

Validation on real infrastructure: a VPN gateway with 259 managed firewall resources and 274 live rules applies its full catalog in ~7 s under `--noop`, with a debug run confirming exactly one `iptables-save` and one `ip6tables-save` execution for the entire agent run.

## Related ticket / issue

- Ticket / issue: #1214

## Required checklist

- [x] Linked the driving ticket or issue above where one exists (a `MODULES-*` ticket via the structured spec template, or a GitHub issue).
- [x] Coverage gate is green (or the baseline is preserved -- coverage was not reduced). New unit specs cover the cache class and both providers' caching/invalidation behaviour; full suite passes (1314 examples).
- [ ] Platform matrix is green -- deferring to this PR's CI checks.
- [x] `Co-Authored-By: Claude` trailer is present on the commits if this PR was AI-assisted. This PR was AI-assisted (Claude); the trailer is on the commit.

## Review policy (outcome-based)

This PR is (check one):

- [ ] Auto-merge
- [ ] Single reviewer
- [x] Full review (2+)

## Additional context

**Regression analysis performed:**

1. *Stale reads after our own writes* - every mutation path in both providers invalidates the cache (chain flush/delete included). Covered by unit specs and an end-to-end drift test.
2. *Stale reads across runs* - the cache keys on the identity of the per-run environment binding; a new agent run, apply invocation, or `puppet resource` process never reuses a snapshot. Where the binding is absent (unusual embeddings), caching disables itself entirely.
3. *Mutation of shared parsed data* - audited the module and puppet-resource_api for in-place mutation of "is" values (`gsub!`, `map!`, `sort!`, index assignment); none apply to cached objects. Defensively, `get_rules` copies hashes and array values per caller anyway.
4. *Mid-run external mutations* (an `exec` running iptables, a service restart reloading saved rules between firewall resources) are no longer observed within the same run. This is identical to the legacy provider's prefetch-once semantics and self-corrects on the next run.
5. *Failure handling* - a failed `iptables-save` is not cached (the exception propagates; the next read retries).
6. *Unmanaged-rule synthetic names* (`9xxx <sha>`) - parse results are cached per call shape, so counter-derived names are identical to previous behaviour.

End-to-end tested with real iptables (nf_tables 1.8.11) and Puppet 8.10: chain + rule catalogs apply correctly, second run fully idempotent with each list command executed exactly once, externally deleted rules re-created in the correct position on the next run, `firewallchain` purge deletes unmanaged rules, `puppet resource firewall` works.

`spec_helper_local.rb` drops the cache before each example because the spec harness, unlike real runs, keeps one `:current_environment` binding across examples.

**Possible follow-ups (out of scope here):**

- Updating the cached snapshot in place after writes, so bootstrap runs creating many rules also avoid re-reads (currently each write invalidates, matching previous `insert_order` behaviour).
- Precompiling the ~150 attribute regexes in `rule_to_hash`/`rule_to_name`, which are currently rebuilt with `Regexp.new` for every rule parsed - this would speed up the one remaining full parse per run.
- Per-transaction `get` caching in puppet-resource_api itself, which would address this class of problem for all resource_api providers.
